### PR TITLE
Feat: 드롭 중인 상품 조회 API 구현

### DIFF
--- a/src/main/java/org/son/sonstudy/domain/product/application/ProductController.java
+++ b/src/main/java/org/son/sonstudy/domain/product/application/ProductController.java
@@ -2,18 +2,19 @@ package org.son.sonstudy.domain.product.application;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.son.sonstudy.common.api.code.ErrorCode;
 import org.son.sonstudy.common.api.code.SuccessCode;
 import org.son.sonstudy.common.api.response.ApiResponse;
+import org.son.sonstudy.common.exception.CustomException;
 import org.son.sonstudy.common.jwt.data.UserContext;
 import org.son.sonstudy.domain.product.application.request.ProductRegistrationRequest;
 import org.son.sonstudy.domain.product.application.request.ScheduledDropsRequest;
 import org.son.sonstudy.domain.product.business.ProductService;
 import org.son.sonstudy.domain.product.business.response.ProductDetailResponse;
+import org.son.sonstudy.domain.product.business.response.ProductLiveResponse;
 import org.son.sonstudy.domain.product.business.response.ProductResponse;
 import org.son.sonstudy.domain.product.business.response.ScheduledDropsResponse;
 import org.son.sonstudy.domain.product.model.ProductStatus;
-import org.son.sonstudy.common.api.code.ErrorCode;
-import org.son.sonstudy.common.exception.CustomException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -71,6 +72,16 @@ public class ProductController {
         String userId = userContext != null ? userContext.userId() : null;
         ScheduledDropsRequest normalized = request.normalize(5);
         ScheduledDropsResponse response = productService.findScheduledDrops(userId, normalized);
+        return ApiResponse.success(SuccessCode.PRODUCT_OK, response);
+    }
+
+    @GetMapping("/live")
+    public ResponseEntity<ApiResponse<ProductLiveResponse>> getLiveDrops(
+            @AuthenticationPrincipal(errorOnInvalidType = false) UserContext userContext,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        String userId = userContext != null ? userContext.userId() : null;
+        ProductLiveResponse response = productService.findLiveDrops(userId, pageable);
         return ApiResponse.success(SuccessCode.PRODUCT_OK, response);
     }
 }

--- a/src/main/java/org/son/sonstudy/domain/product/application/ProductController.java
+++ b/src/main/java/org/son/sonstudy/domain/product/application/ProductController.java
@@ -78,7 +78,7 @@ public class ProductController {
     @GetMapping("/live")
     public ResponseEntity<ApiResponse<ProductLiveResponse>> getLiveDrops(
             @AuthenticationPrincipal(errorOnInvalidType = false) UserContext userContext,
-            @PageableDefault(size = 10) Pageable pageable
+            @PageableDefault(size = 3) Pageable pageable
     ) {
         String userId = userContext != null ? userContext.userId() : null;
         ProductLiveResponse response = productService.findLiveDrops(userId, pageable);

--- a/src/main/java/org/son/sonstudy/domain/product/business/ProductService.java
+++ b/src/main/java/org/son/sonstudy/domain/product/business/ProductService.java
@@ -3,6 +3,7 @@ package org.son.sonstudy.domain.product.business;
 import org.son.sonstudy.domain.product.application.request.ProductRegistrationRequest;
 import org.son.sonstudy.domain.product.application.request.ScheduledDropsRequest;
 import org.son.sonstudy.domain.product.business.response.ProductDetailResponse;
+import org.son.sonstudy.domain.product.business.response.ProductLiveResponse;
 import org.son.sonstudy.domain.product.business.response.ProductResponse;
 import org.son.sonstudy.domain.product.business.response.ScheduledDropsResponse;
 import org.springframework.data.domain.Pageable;
@@ -16,4 +17,6 @@ public interface ProductService {
     ProductDetailResponse findProductDetail(String productId);
 
     ScheduledDropsResponse findScheduledDrops(String userId, ScheduledDropsRequest request);
+
+    ProductLiveResponse findLiveDrops(String userId, Pageable pageable);
 }

--- a/src/main/java/org/son/sonstudy/domain/product/business/ProductServiceImpl.java
+++ b/src/main/java/org/son/sonstudy/domain/product/business/ProductServiceImpl.java
@@ -131,11 +131,6 @@ public class ProductServiceImpl implements ProductService {
     public ProductLiveResponse findLiveDrops(String userId, Pageable pageable) {
         Slice<Product> slice;
 
-        if (userId == null) {
-            slice = productRepository.findLiveDropsWithoutUser(pageable);
-            return ProductLiveResponse.from(slice, new HashSet<>(), new HashSet<>());
-        }
-
         slice = productRepository.findLiveDrops(userId, pageable);
 
         Set<String> likedProductIds = new HashSet<>();

--- a/src/main/java/org/son/sonstudy/domain/product/business/ProductServiceImpl.java
+++ b/src/main/java/org/son/sonstudy/domain/product/business/ProductServiceImpl.java
@@ -16,6 +16,7 @@ import org.son.sonstudy.domain.product.model.submodel.ColorRepository;
 import org.son.sonstudy.domain.product.model.submodel.ProductImage;
 import org.son.sonstudy.domain.product.repository.ProductLikeRepository;
 import org.son.sonstudy.domain.product.repository.ProductNotificationRepository;
+import org.son.sonstudy.domain.product.repository.ProductOptionRepository;
 import org.son.sonstudy.domain.product.repository.ProductRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -26,7 +27,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -36,6 +39,7 @@ public class ProductServiceImpl implements ProductService {
     private final ColorRepository colorRepository;
     private final ProductLikeRepository productLikeRepository;
     private final ProductNotificationRepository productNotificationRepository;
+    private final ProductOptionRepository productOptionRepository;
 
     @Override
     @Transactional
@@ -53,16 +57,6 @@ public class ProductServiceImpl implements ProductService {
                 request.category()
         );
 
-        for (var optionDto : request.options()) {
-            ProductOption option = ProductOption.builder()
-                    .size(optionDto.size())
-                    .cost(optionDto.cost())
-                    .stock(optionDto.stock())
-                    .build();
-
-            product.addOption(option);
-        }
-
         for (int i = 0; i < request.imageUrls().size(); i++) {
             ProductImage image = ProductImage.builder()
                     .imageUrl(request.imageUrls().get(i))
@@ -73,6 +67,17 @@ public class ProductServiceImpl implements ProductService {
         }
 
         productRepository.save(product);
+
+        for (var optionDto : request.options()) {
+            ProductOption option = ProductOption.builder()
+                    .size(optionDto.size())
+                    .cost(optionDto.cost())
+                    .stock(optionDto.stock())
+                    .build();
+
+            option.setProduct(product);
+            productOptionRepository.save(option);
+        }
     }
 
     @Override
@@ -89,7 +94,9 @@ public class ProductServiceImpl implements ProductService {
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
 
-        return ProductDetailResponse.from(product);
+        List<ProductOption> options = productOptionRepository.findByProductId(productId);
+
+        return ProductDetailResponse.from(product, options);
     }
 
     @Override
@@ -107,50 +114,66 @@ public class ProductServiceImpl implements ProductService {
 
         Set<String> likedProductIds = new HashSet<>();
         Set<String> notificationEnabledProductIds = new HashSet<>();
-        if (userId != null && !content.isEmpty()) {
+        Map<String, List<ProductOption>> optionsByProductId = Map.of();
+
+        if (!content.isEmpty()) {
             List<String> productIds = content.stream()
                     .map(Product::getId)
                     .toList();
-            likedProductIds.addAll(
-                    productLikeRepository.findLikedProductIds(userId, productIds)
-            );
-            notificationEnabledProductIds.addAll(
-                    productNotificationRepository.findNotificationEnabledProductIds(userId, productIds)
-            );
+
+            optionsByProductId = productOptionRepository.findByProductIds(productIds).stream()
+                    .collect(Collectors.groupingBy(option -> option.getProduct().getId()));
+
+            if (userId != null) {
+                likedProductIds.addAll(
+                        productLikeRepository.findLikedProductIds(userId, productIds)
+                );
+                notificationEnabledProductIds.addAll(
+                        productNotificationRepository.findNotificationEnabledProductIds(userId, productIds)
+                );
+            }
         }
 
         return ScheduledDropsResponse.from(
                 slice,
                 likedProductIds,
-                notificationEnabledProductIds
+                notificationEnabledProductIds,
+                optionsByProductId
         );
     }
 
     @Override
     @Transactional(readOnly = true)
     public ProductLiveResponse findLiveDrops(String userId, Pageable pageable) {
-        Slice<Product> slice;
-
-        slice = productRepository.findLiveDrops(userId, pageable);
+        Slice<Product> slice = productRepository.findLiveDrops(userId, pageable);
 
         Set<String> likedProductIds = new HashSet<>();
         Set<String> notificationEnabledProductIds = new HashSet<>();
+        Map<String, List<ProductOption>> optionsByProductId = Map.of();
+
         if (!slice.isEmpty()) {
             List<String> productIds = slice.getContent().stream()
                     .map(Product::getId)
                     .toList();
-            likedProductIds.addAll(
-                    productLikeRepository.findLikedProductIds(userId, productIds)
-            );
-            notificationEnabledProductIds.addAll(
-                    productNotificationRepository.findNotificationEnabledProductIds(userId, productIds)
-            );
+
+            optionsByProductId = productOptionRepository.findByProductIds(productIds).stream()
+                    .collect(Collectors.groupingBy(option -> option.getProduct().getId()));
+
+            if (userId != null) {
+                likedProductIds.addAll(
+                        productLikeRepository.findLikedProductIds(userId, productIds)
+                );
+                notificationEnabledProductIds.addAll(
+                        productNotificationRepository.findNotificationEnabledProductIds(userId, productIds)
+                );
+            }
         }
 
         return ProductLiveResponse.from(
                 slice,
                 likedProductIds,
-                notificationEnabledProductIds
+                notificationEnabledProductIds,
+                optionsByProductId
         );
     }
 

--- a/src/main/java/org/son/sonstudy/domain/product/business/ProductServiceImpl.java
+++ b/src/main/java/org/son/sonstudy/domain/product/business/ProductServiceImpl.java
@@ -6,6 +6,7 @@ import org.son.sonstudy.common.exception.CustomException;
 import org.son.sonstudy.domain.product.application.request.ProductRegistrationRequest;
 import org.son.sonstudy.domain.product.application.request.ScheduledDropsRequest;
 import org.son.sonstudy.domain.product.business.response.ProductDetailResponse;
+import org.son.sonstudy.domain.product.business.response.ProductLiveResponse;
 import org.son.sonstudy.domain.product.business.response.ProductResponse;
 import org.son.sonstudy.domain.product.business.response.ScheduledDropsResponse;
 import org.son.sonstudy.domain.product.model.Product;
@@ -119,6 +120,39 @@ public class ProductServiceImpl implements ProductService {
         }
 
         return ScheduledDropsResponse.from(
+                slice,
+                likedProductIds,
+                notificationEnabledProductIds
+        );
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ProductLiveResponse findLiveDrops(String userId, Pageable pageable) {
+        Slice<Product> slice;
+
+        if (userId == null) {
+            slice = productRepository.findLiveDropsWithoutUser(pageable);
+            return ProductLiveResponse.from(slice, new HashSet<>(), new HashSet<>());
+        }
+
+        slice = productRepository.findLiveDrops(userId, pageable);
+
+        Set<String> likedProductIds = new HashSet<>();
+        Set<String> notificationEnabledProductIds = new HashSet<>();
+        if (!slice.isEmpty()) {
+            List<String> productIds = slice.getContent().stream()
+                    .map(Product::getId)
+                    .toList();
+            likedProductIds.addAll(
+                    productLikeRepository.findLikedProductIds(userId, productIds)
+            );
+            notificationEnabledProductIds.addAll(
+                    productNotificationRepository.findNotificationEnabledProductIds(userId, productIds)
+            );
+        }
+
+        return ProductLiveResponse.from(
                 slice,
                 likedProductIds,
                 notificationEnabledProductIds

--- a/src/main/java/org/son/sonstudy/domain/product/business/response/ProductDetailResponse.java
+++ b/src/main/java/org/son/sonstudy/domain/product/business/response/ProductDetailResponse.java
@@ -23,13 +23,13 @@ public record ProductDetailResponse(
         LocalDateTime releasedAt,
         List<OptionResponse> options
 ) {
-    public static ProductDetailResponse from(Product product) {
+    public static ProductDetailResponse from(Product product, List<ProductOption> options) {
         List<String> images = product.getImages().stream()
                 .sorted(Comparator.comparingInt(ProductImage::getOrders))
                 .map(ProductImage::getImageUrl)
                 .toList();
 
-        List<OptionResponse> options = product.getOptions().stream()
+        List<OptionResponse> optionResponses = options.stream()
                 .map(OptionResponse::from)
                 .toList();
 
@@ -44,7 +44,7 @@ public record ProductDetailResponse(
                 product.getCategory(),
                 product.getStatus(),
                 product.getReleasedAt(),
-                options
+                optionResponses
         );
     }
 

--- a/src/main/java/org/son/sonstudy/domain/product/business/response/ProductLiveResponse.java
+++ b/src/main/java/org/son/sonstudy/domain/product/business/response/ProductLiveResponse.java
@@ -1,0 +1,77 @@
+package org.son.sonstudy.domain.product.business.response;
+
+import org.son.sonstudy.domain.product.model.Product;
+import org.son.sonstudy.domain.product.model.ProductOption;
+import org.son.sonstudy.domain.product.model.submodel.ProductImage;
+import org.springframework.data.domain.Slice;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+
+public record ProductLiveResponse(
+        List<ProductLiveElement> content,
+        int pageNumber,
+        int pageSize,
+        boolean hasNext
+) {
+    public static ProductLiveResponse from(
+            Slice<Product> slice,
+            Set<String> likedProductIds,
+            Set<String> notificationEnabledProductIds
+    ) {
+        List<ProductLiveElement> content = slice.getContent().stream()
+                .map(product -> ProductLiveElement.from(
+                        product,
+                        likedProductIds.contains(product.getId()),
+                        notificationEnabledProductIds.contains(product.getId())
+                ))
+                .toList();
+
+        return new ProductLiveResponse(
+                content,
+                slice.getNumber(),
+                slice.getSize(),
+                slice.hasNext()
+        );
+    }
+
+    public record ProductLiveElement(
+            String id,
+            String imageUrl,
+            LocalDateTime releasedAt,
+            String brand,
+            String name,
+            int price,
+            boolean notificationEnabled,
+            boolean liked
+    ) {
+        public static ProductLiveElement from(
+                Product product,
+                boolean liked,
+                boolean notificationEnabled
+        ) {
+            String imageUrl = product.getImages().stream()
+                    .min(Comparator.comparingInt(ProductImage::getOrders))
+                    .map(ProductImage::getImageUrl)
+                    .orElse(null);
+
+            int price = product.getOptions().stream()
+                    .mapToInt(ProductOption::getCost)
+                    .min()
+                    .orElse(0);
+
+            return new ProductLiveElement(
+                    product.getId(),
+                    imageUrl,
+                    product.getReleasedAt(),
+                    product.getBrand(),
+                    product.getName(),
+                    price,
+                    notificationEnabled,
+                    liked
+            );
+        }
+    }
+}

--- a/src/main/java/org/son/sonstudy/domain/product/business/response/ProductLiveResponse.java
+++ b/src/main/java/org/son/sonstudy/domain/product/business/response/ProductLiveResponse.java
@@ -2,6 +2,7 @@ package org.son.sonstudy.domain.product.business.response;
 
 import org.son.sonstudy.domain.product.model.Product;
 import org.son.sonstudy.domain.product.model.ProductOption;
+import org.son.sonstudy.domain.product.model.ProductStatus;
 import org.son.sonstudy.domain.product.model.submodel.ProductImage;
 import org.springframework.data.domain.Slice;
 
@@ -44,6 +45,8 @@ public record ProductLiveResponse(
             String brand,
             String name,
             int price,
+            int stock,
+            ProductStatus status,
             boolean notificationEnabled,
             boolean liked
     ) {
@@ -62,6 +65,11 @@ public record ProductLiveResponse(
                     .min()
                     .orElse(0);
 
+            int stock = product.getOptions().stream()
+                    .mapToInt(ProductOption::getStock)
+                    .min()
+                    .orElse(0);
+
             return new ProductLiveElement(
                     product.getId(),
                     imageUrl,
@@ -69,6 +77,8 @@ public record ProductLiveResponse(
                     product.getBrand(),
                     product.getName(),
                     price,
+                    stock,
+                    product.getStatus(),
                     notificationEnabled,
                     liked
             );

--- a/src/main/java/org/son/sonstudy/domain/product/business/response/ProductLiveResponse.java
+++ b/src/main/java/org/son/sonstudy/domain/product/business/response/ProductLiveResponse.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Slice;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public record ProductLiveResponse(
@@ -20,13 +21,15 @@ public record ProductLiveResponse(
     public static ProductLiveResponse from(
             Slice<Product> slice,
             Set<String> likedProductIds,
-            Set<String> notificationEnabledProductIds
+            Set<String> notificationEnabledProductIds,
+            Map<String, List<ProductOption>> optionsByProductId
     ) {
         List<ProductLiveElement> content = slice.getContent().stream()
                 .map(product -> ProductLiveElement.from(
                         product,
                         likedProductIds.contains(product.getId()),
-                        notificationEnabledProductIds.contains(product.getId())
+                        notificationEnabledProductIds.contains(product.getId()),
+                        optionsByProductId.getOrDefault(product.getId(), List.of())
                 ))
                 .toList();
 
@@ -53,19 +56,20 @@ public record ProductLiveResponse(
         public static ProductLiveElement from(
                 Product product,
                 boolean liked,
-                boolean notificationEnabled
+                boolean notificationEnabled,
+                List<ProductOption> options
         ) {
             String imageUrl = product.getImages().stream()
                     .min(Comparator.comparingInt(ProductImage::getOrders))
                     .map(ProductImage::getImageUrl)
                     .orElse(null);
 
-            int price = product.getOptions().stream()
+            int price = options.stream()
                     .mapToInt(ProductOption::getCost)
                     .min()
                     .orElse(0);
 
-            int stock = product.getOptions().stream()
+            int stock = options.stream()
                     .mapToInt(ProductOption::getStock)
                     .min()
                     .orElse(0);

--- a/src/main/java/org/son/sonstudy/domain/product/business/response/ScheduledDropsResponse.java
+++ b/src/main/java/org/son/sonstudy/domain/product/business/response/ScheduledDropsResponse.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Slice;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public record ScheduledDropsResponse(
@@ -19,13 +20,15 @@ public record ScheduledDropsResponse(
     public static ScheduledDropsResponse from(
             Slice<Product> products,
             Set<String> likedProductIds,
-            Set<String> notificationEnabledProductIds
+            Set<String> notificationEnabledProductIds,
+            Map<String, List<ProductOption>> optionsByProductId
     ) {
         List<ScheduledDropElement> content = products.getContent().stream()
                 .map(product -> ScheduledDropElement.from(
                         product,
                         likedProductIds.contains(product.getId()),
-                        notificationEnabledProductIds.contains(product.getId())
+                        notificationEnabledProductIds.contains(product.getId()),
+                        optionsByProductId.getOrDefault(product.getId(), List.of())
                 ))
                 .toList();
 
@@ -56,19 +59,20 @@ public record ScheduledDropsResponse(
         public static ScheduledDropElement from(
                 Product product,
                 boolean liked,
-                boolean notificationEnabled
+                boolean notificationEnabled,
+                List<ProductOption> options
         ) {
             String imageUrl = product.getImages().stream()
                     .min(Comparator.comparingInt(ProductImage::getOrders))
                     .map(ProductImage::getImageUrl)
                     .orElse(null);
 
-            int price = product.getOptions().stream()
+            int price = options.stream()
                     .mapToInt(ProductOption::getCost)
                     .min()
                     .orElse(0);
 
-            int stock = product.getOptions().stream()
+            int stock = options.stream()
                     .mapToInt(ProductOption::getStock)
                     .sum();
 

--- a/src/main/java/org/son/sonstudy/domain/product/model/Product.java
+++ b/src/main/java/org/son/sonstudy/domain/product/model/Product.java
@@ -47,9 +47,6 @@ public class Product {
     @Enumerated(EnumType.STRING)
     private ProductStatus status;
 
-    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL)
-    private List<ProductOption> options = new ArrayList<>();
-
     @Builder
     private Product(String name, String description, String brand, Color color,
                     LocalDateTime releasedAt, ProductCategory category, ProductStatus status) {
@@ -73,11 +70,6 @@ public class Product {
                 .category(category)
                 .status(ProductStatus.SCHEDULED)
                 .build();
-    }
-
-    public void addOption(ProductOption option) {
-        this.options.add(option);
-        option.setProduct(this);
     }
 
     public void addImage(ProductImage image) {

--- a/src/main/java/org/son/sonstudy/domain/product/repository/ProductOptionRepository.java
+++ b/src/main/java/org/son/sonstudy/domain/product/repository/ProductOptionRepository.java
@@ -1,0 +1,15 @@
+package org.son.sonstudy.domain.product.repository;
+
+import org.son.sonstudy.domain.product.model.ProductOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ProductOptionRepository extends JpaRepository<ProductOption, String> {
+    List<ProductOption> findByProductId(String productId);
+
+    @Query("SELECT po FROM ProductOption po WHERE po.product.id IN :productIds")
+    List<ProductOption> findByProductIds(@Param("productIds") List<String> productIds);
+}

--- a/src/main/java/org/son/sonstudy/domain/product/repository/ProductRepositoryCustom.java
+++ b/src/main/java/org/son/sonstudy/domain/product/repository/ProductRepositoryCustom.java
@@ -1,10 +1,16 @@
 package org.son.sonstudy.domain.product.repository;
 
 import org.son.sonstudy.domain.product.model.Product;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ProductRepositoryCustom {
     List<Product> findScheduledDropsByCursor(LocalDateTime cursorReleasedAt, String cursorId, int size);
+
+    Slice<Product> findLiveDrops(String userId, Pageable pageable);
+
+    Slice<Product> findLiveDropsWithoutUser(Pageable pageable);
 }

--- a/src/main/java/org/son/sonstudy/domain/product/repository/ProductRepositoryCustom.java
+++ b/src/main/java/org/son/sonstudy/domain/product/repository/ProductRepositoryCustom.java
@@ -11,6 +11,4 @@ public interface ProductRepositoryCustom {
     List<Product> findScheduledDropsByCursor(LocalDateTime cursorReleasedAt, String cursorId, int size);
 
     Slice<Product> findLiveDrops(String userId, Pageable pageable);
-
-    Slice<Product> findLiveDropsWithoutUser(Pageable pageable);
 }

--- a/src/main/java/org/son/sonstudy/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/org/son/sonstudy/domain/product/repository/ProductRepositoryImpl.java
@@ -1,11 +1,14 @@
 package org.son.sonstudy.domain.product.repository;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.son.sonstudy.domain.product.model.Product;
-import org.son.sonstudy.domain.product.model.ProductStatus;
-import org.son.sonstudy.domain.product.model.QProduct;
+import org.son.sonstudy.domain.product.model.*;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -31,6 +34,84 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                 .orderBy(product.releasedAt.asc(), product.id.asc())
                 .limit(size + 1L) // size + 1개 만큼 조회해서 hasNext가 있는지 판별함
                 .fetch();
+    }
+
+    @Override
+    public Slice<Product> findLiveDrops(String userId, Pageable pageable) {
+        QProduct product = QProduct.product;
+        QProductOption option = QProductOption.productOption;
+        QProductLike productLike = QProductLike.productLike;
+
+        // (좋아요=0, 아니면=1)
+        NumberExpression<Integer> likeOrder = new CaseBuilder()
+                .when(productLike.id.isNotNull()).then(0)
+                .otherwise(1);
+
+        // (ON_SALE=0, END=1)
+        NumberExpression<Integer> statusOrder = new CaseBuilder()
+                .when(product.status.eq(ProductStatus.ON_SALE)).then(0)
+                .otherwise(1);
+
+        List<Product> content = queryFactory
+                .selectFrom(product)
+                .leftJoin(product.options, option)
+                .leftJoin(productLike).on(product.id.eq(productLike.product.id)
+                        .and(productLike.user.id.eq(userId)))
+                .where(
+                        product.status.eq(ProductStatus.ON_SALE)
+                                .or(product.status.eq(ProductStatus.END).and(option.stock.gt(0)))
+                )
+                .groupBy(product.id)
+                .orderBy(
+                        likeOrder.asc(),          // 1. 좋아요 먼저
+                        statusOrder.asc(),        // 2. ON_SALE 상태 먼저
+                        option.stock.sum().asc(), // 3. 재고 적은 순
+                        product.id.desc()
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        boolean hasNext = content.size() > pageable.getPageSize();
+        if (hasNext) {
+            content.remove(content.size() - 1);
+        }
+
+        return new SliceImpl<>(content, pageable, hasNext);
+    }
+
+    @Override
+    public Slice<Product> findLiveDropsWithoutUser(Pageable pageable) {
+        QProduct product = QProduct.product;
+        QProductOption option = QProductOption.productOption;
+
+        NumberExpression<Integer> statusOrder = new CaseBuilder()
+                .when(product.status.eq(ProductStatus.ON_SALE)).then(0)
+                .otherwise(1);
+
+        List<Product> content = queryFactory
+                .selectFrom(product)
+                .leftJoin(product.options, option)
+                .where(
+                        product.status.eq(ProductStatus.ON_SALE)
+                                .or(product.status.eq(ProductStatus.END).and(option.stock.gt(0)))
+                )
+                .groupBy(product.id)
+                .orderBy(
+                        statusOrder.asc(),
+                        option.stock.sum().asc(),
+                        product.id.desc()
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        boolean hasNext = content.size() > pageable.getPageSize();
+        if (hasNext) {
+            content.remove(content.size() - 1);
+        }
+
+        return new SliceImpl<>(content, pageable, hasNext);
     }
 
     private BooleanBuilder buildCursorPredicate(

--- a/src/main/java/org/son/sonstudy/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/org/son/sonstudy/domain/product/repository/ProductRepositoryImpl.java
@@ -3,6 +3,7 @@ package org.son.sonstudy.domain.product.repository;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.son.sonstudy.domain.product.model.*;
@@ -52,54 +53,26 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                 .when(product.status.eq(ProductStatus.ON_SALE)).then(0)
                 .otherwise(1);
 
-        List<Product> content = queryFactory
+        JPAQuery<Product> query = queryFactory
                 .selectFrom(product)
-                .leftJoin(product.options, option)
-                .leftJoin(productLike).on(product.id.eq(productLike.product.id)
-                        .and(productLike.user.id.eq(userId)))
-                .where(
-                        product.status.eq(ProductStatus.ON_SALE)
-                                .or(product.status.eq(ProductStatus.END).and(option.stock.gt(0)))
-                )
-                .groupBy(product.id)
-                .orderBy(
-                        likeOrder.asc(),          // 1. 좋아요 먼저
-                        statusOrder.asc(),        // 2. ON_SALE 상태 먼저
-                        option.stock.sum().asc(), // 3. 재고 적은 순
-                        product.id.desc()
-                )
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize() + 1)
-                .fetch();
+                .leftJoin(product.options, option);
 
-        boolean hasNext = content.size() > pageable.getPageSize();
-        if (hasNext) {
-            content.remove(content.size() - 1);
+        if (userId != null) {
+            query.leftJoin(productLike).on(product.id.eq(productLike.product.id)
+                    .and(productLike.user.id.eq(userId)));
         }
 
-        return new SliceImpl<>(content, pageable, hasNext);
-    }
-
-    @Override
-    public Slice<Product> findLiveDropsWithoutUser(Pageable pageable) {
-        QProduct product = QProduct.product;
-        QProductOption option = QProductOption.productOption;
-
-        NumberExpression<Integer> statusOrder = new CaseBuilder()
-                .when(product.status.eq(ProductStatus.ON_SALE)).then(0)
-                .otherwise(1);
-
-        List<Product> content = queryFactory
-                .selectFrom(product)
-                .leftJoin(product.options, option)
+        List<Product> content = query
                 .where(
                         product.status.eq(ProductStatus.ON_SALE)
                                 .or(product.status.eq(ProductStatus.END).and(option.stock.gt(0)))
                 )
                 .groupBy(product.id)
                 .orderBy(
-                        statusOrder.asc(),
-                        option.stock.sum().asc(),
+                        // userId가 있을 때만 likeOrder 적용, 없으면 null 처리되어 무시됨
+                        userId != null ? likeOrder.asc() : null,
+                        statusOrder.asc(),        // 1. (혹은 2.) ON_SALE 상태 먼저
+                        option.stock.sum().asc(), // 2. (혹은 3.) 재고 적은 순
                         product.id.desc()
                 )
                 .offset(pageable.getOffset())

--- a/src/main/java/org/son/sonstudy/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/org/son/sonstudy/domain/product/repository/ProductRepositoryImpl.java
@@ -55,7 +55,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 
         JPAQuery<Product> query = queryFactory
                 .selectFrom(product)
-                .leftJoin(product.options, option);
+                .leftJoin(option).on(option.product.id.eq(product.id));
 
         if (userId != null) {
             query.leftJoin(productLike).on(product.id.eq(productLike.product.id)


### PR DESCRIPTION
## 📌 Issue
<!-- 관련 이슈 번호 -->
- closes #19 #23 

## ✍️ Summary
<!-- 이슈에 대한 설명 -->
1. 좋아요 순 2. ON_SALE - END 순 3. 그 외에 재고 적은 순으로 정렬. 페이징으로 구현 
2. onetomany 양방향 제약 제거

## 📢 Notify
<!-- 리뷰어 참고 사항-->
상태 변경을 위해 필요한 로직은 이슈 확인 #20 
양방향 의존 리팩터링은 필요한 수정사항 정리 후, 동엽님에게 전달 예정

## Learning
###  1. FK 관리
 저는 양방향 의존 관계를 사용해서, N+1 상황에 대해서는 적절히 fetch join하는 전략을 주로 이용했습니다. 
 양방향 방식은 Cascade 설정이나 데이터 조회에 간편하다는 장점이 있지만, 잘못된 직렬화 시 "무한 참조 순환"이나 강한 의존성에  씨앗이 될 수 있습니다.
 그래서 리팩터링으로 단방향 의존으로 수정하였습니다. 이 방법은 낮은 의존도와 FK 정합성 모두를 챙기는 방식입니다. 그러나 반드시 단방향이 양방향 관계보다 적잘한 코드냐 하면 그건 아닌 것 같습니다. 부모와 자식 객체가 애초에 도메인 규칙 상 강한 의존도를 갖는다면, 양방향 설정 후 JPA 기능을 활용하는 편이 리소스를 아끼는 방법이 될 수 있습니다.
 또한, 단방향보다 유연한 구조로는 논리적 제약만 거는 방식이 있습니다. FK 설정을 사용하지 않고, 직접 자식객체 필드에 부모 객체 id를 넣는 방식입니다. 둘 사이에 어떤 물리적 제약이 없기 때문에, OOP 측면에서는 단방향보다 뛰어난데요. 대신, 고아객체 문제처럼 FK가 제약을 걸어주던 정합성 문제를 직접 개발자가 관리해야 하는 문제도 있습니다. 
