### PR TITLE
Feat/#20 status field 이동

### DIFF
--- a/src/main/java/org/son/sonstudy/common/api/code/ErrorCode.java
+++ b/src/main/java/org/son/sonstudy/common/api/code/ErrorCode.java
@@ -37,7 +37,8 @@ public enum ErrorCode {
     INVALID_PRODUCT_COST("DC400_301", HttpStatus.BAD_REQUEST, "상품 가격은 0원 이상이어야 합니다."),
     INVALID_PRODUCT_SIZE("DC400_302", HttpStatus.BAD_REQUEST, "유효하지 않은 상품 사이즈입니다."),
     INVALID_STOCK("DC400_303", HttpStatus.BAD_REQUEST, "재고량은 음수가 될 수 없습니다."),
-    INVALID_IMAGE_SIZE("DC400_304", HttpStatus.BAD_REQUEST, "상품 이미지는 1-10장 사이여야 합니다.");
+    INVALID_IMAGE_SIZE("DC400_304", HttpStatus.BAD_REQUEST, "상품 이미지는 1-10장 사이여야 합니다."),
+    INVALID_PRODUCT_STATE("DC400_305", HttpStatus.BAD_REQUEST , "상품 판매 상태가 정의되지 않았습니다." ),;
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/org/son/sonstudy/domain/product/model/Product.java
+++ b/src/main/java/org/son/sonstudy/domain/product/model/Product.java
@@ -44,19 +44,20 @@ public class Product {
     @Enumerated(EnumType.STRING)
     private ProductCategory category;
 
-    @Enumerated(EnumType.STRING)
-    private ProductStatus status;
+    @Column(nullable = false)
+    private Boolean isDisplay;
+
 
     @Builder
     private Product(String name, String description, String brand, Color color,
-                    LocalDateTime releasedAt, ProductCategory category, ProductStatus status) {
+                    LocalDateTime releasedAt, ProductCategory category, Boolean isDisplay) {
         this.name = name;
         this.description = description;
         this.brand = brand;
         this.color = color;
         this.releasedAt = releasedAt;
         this.category = category;
-        this.status = status;
+        this.isDisplay = isDisplay;
     }
 
     public static Product createProduct(String name, String description, String brand, Color color,
@@ -68,7 +69,7 @@ public class Product {
                 .color(color)
                 .releasedAt(releasedAt)
                 .category(category)
-                .status(ProductStatus.SCHEDULED)
+                .isDisplay(true)
                 .build();
     }
 

--- a/src/main/java/org/son/sonstudy/domain/product/model/ProductOption.java
+++ b/src/main/java/org/son/sonstudy/domain/product/model/ProductOption.java
@@ -32,16 +32,21 @@ public class ProductOption {
     @Column(nullable = false)
     private Long totalSales;
 
+    @Enumerated(EnumType.STRING)
+    private ProductStatus status;
+
     @Builder
-    public ProductOption(int size, int cost, int stock) {
+    public ProductOption(int size, int cost, int stock, ProductStatus status) {
         validateSize(size);
         validateCost(cost);
         validateStock(stock);
+        validateStatus(status);
 
         this.size = size;
         this.cost = cost;
         this.stock = stock;
         this.totalSales = 0L;
+        this.status = status;
     }
 
     private void validateSize(int size) {
@@ -61,4 +66,10 @@ public class ProductOption {
             throw new CustomException(ErrorCode.INVALID_STOCK);
         }
     }
+    private void validateStatus(ProductStatus status) {
+        if (status == null) {
+            throw new CustomException(ErrorCode.INVALID_PRODUCT_STATE);
+        }
+    }
+
 }


### PR DESCRIPTION
## 📌 Issue
<!-- 관련 이슈 번호 -->
- closed [#20]

## ✍️ Summary
<!-- 이슈에 대한 설명 -->
1. Product에 있던 status field를 ProductOption으로 이동
2. 이에 따라 기존 createProduct에서 status를 설정할 수 없어졌기에, isDisplay를 새로 만들어 사이즈에 관련없이 한 상품을 보여주거나 보여주지 않게 설정
3. status가 비어있을 때 반환하는 새로운 ErrorCode 추가.

## 📢 Notify
<!-- 리뷰어 참고 사항-->
일단 제가 이해한 내용 바탕으로 수정했습니다. ProductOption에서 필드값이 유효한 지 체크하는 로직이 있어 status도 따라 구현했습니다.
isDisplay는 없으면 사이즈별로 다 status를 체크해 상품을 보여줄 지 말지를 정할 수 있기에 편의성을 위해 추가해 보았는데요,, 괜찮을지 모르겠습니다. 의도가 이해가 안되는 부분이나 회의한 내용과 다르게 구현된 부분 있으면 말씀해주시면 감사하겠습니다!!
