### PR TITLE
feat: product 에서도 status 추가

### DIFF
--- a/src/main/java/org/son/sonstudy/domain/product/application/ProductController.java
+++ b/src/main/java/org/son/sonstudy/domain/product/application/ProductController.java
@@ -80,7 +80,7 @@ public class ProductController {
             @AuthenticationPrincipal(errorOnInvalidType = false) UserContext userContext,
             @PageableDefault(size = 3) Pageable pageable
     ) {
-        String userId = userContext != null ? userContext.userId() : null;
+        String userId = userContext.userId();
         ProductLiveResponse response = productService.findLiveDrops(userId, pageable);
         return ApiResponse.success(SuccessCode.PRODUCT_OK, response);
     }

--- a/src/main/java/org/son/sonstudy/domain/product/model/Product.java
+++ b/src/main/java/org/son/sonstudy/domain/product/model/Product.java
@@ -44,13 +44,16 @@ public class Product {
     @Enumerated(EnumType.STRING)
     private ProductCategory category;
 
+    @Enumerated(EnumType.STRING)
+    private ProductStatus status;
+
     @Column(nullable = false)
     private Boolean isDisplay;
 
 
     @Builder
     private Product(String name, String description, String brand, Color color,
-                    LocalDateTime releasedAt, ProductCategory category, Boolean isDisplay) {
+                    LocalDateTime releasedAt, ProductCategory category, ProductStatus status, Boolean isDisplay) {
         this.name = name;
         this.description = description;
         this.brand = brand;
@@ -70,6 +73,7 @@ public class Product {
                 .releasedAt(releasedAt)
                 .category(category)
                 .isDisplay(true)
+                .status(ProductStatus.SCHEDULED)
                 .build();
     }
 


### PR DESCRIPTION
## 📌 Issue
<!-- 관련 이슈 번호 -->
- closed #26 

## ✍️ Summary
<!-- 이슈에 대한 설명 -->
- 저번에 말한 것처럼, product에서도 status 관리하는 것이 이득이 더 클 것 같습니다.
   status 변경 로직 전에, 주문 로직 만들 거라면 현재 live 조회 기능 유지해도 될 것 같습니다
- live 조회 정렬 흐름으로는 "1. 로그인 상태에서 조회 시, 찜 했는지 -> 재고가 적은 순 2. 비로그인 조회 시, 재고 적은 순"입니다

## 📢 Notify
<!-- 리뷰어 참고 사항-->
