### PR TITLE
[Feat/#30] 주문 생성 API 구현

### DIFF
--- a/src/main/java/org/son/sonstudy/domain/order/application/OrderController.java
+++ b/src/main/java/org/son/sonstudy/domain/order/application/OrderController.java
@@ -1,0 +1,37 @@
+package org.son.sonstudy.domain.order.application;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.son.sonstudy.common.api.response.ApiResponse;
+import org.son.sonstudy.common.jwt.data.UserContext;
+import org.son.sonstudy.domain.order.application.request.CheckoutRequest;
+import org.son.sonstudy.domain.order.business.OrderService;
+import org.son.sonstudy.domain.order.business.response.CheckoutResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.son.sonstudy.common.api.code.SuccessCode;
+
+@RestController
+@RequestMapping("/api/orders")
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @PostMapping("/checkout")
+    public ResponseEntity<ApiResponse<CheckoutResponse>> checkout(
+            @AuthenticationPrincipal UserContext userContext,
+            @RequestBody @Valid CheckoutRequest request
+    ) {
+        CheckoutResponse response = orderService.checkout(
+                userContext.userId(),
+                request
+        );
+
+        return ApiResponse.success(SuccessCode.CREATED , response);
+    }
+}

--- a/src/main/java/org/son/sonstudy/domain/order/application/request/CheckoutRequest.java
+++ b/src/main/java/org/son/sonstudy/domain/order/application/request/CheckoutRequest.java
@@ -1,0 +1,14 @@
+package org.son.sonstudy.domain.order.application.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import org.son.sonstudy.domain.payment.model.PaymentMethod;
+
+public record CheckoutRequest(
+        @NotBlank String productOptionId,
+        @NotNull PaymentMethod paymentMethod,
+        @Positive Long amount,
+        @NotBlank String idempotencyKey
+) {
+}

--- a/src/main/java/org/son/sonstudy/domain/order/business/OrderService.java
+++ b/src/main/java/org/son/sonstudy/domain/order/business/OrderService.java
@@ -1,0 +1,99 @@
+package org.son.sonstudy.domain.order.business;
+
+import lombok.RequiredArgsConstructor;
+import org.son.sonstudy.common.api.code.ErrorCode;
+import org.son.sonstudy.common.exception.CustomException;
+import org.son.sonstudy.domain.order.application.request.CheckoutRequest;
+import org.son.sonstudy.domain.order.business.response.CheckoutResponse;
+import org.son.sonstudy.domain.order.model.Order;
+import org.son.sonstudy.domain.order.repository.OrderRepository;
+import org.son.sonstudy.domain.payment.business.pg.PaymentApproveCommand;
+import org.son.sonstudy.domain.payment.business.pg.PaymentGateway;
+import org.son.sonstudy.domain.payment.business.pg.PaymentGatewayResult;
+import org.son.sonstudy.domain.payment.model.Payment;
+import org.son.sonstudy.domain.payment.repository.PaymentRepository;
+import org.son.sonstudy.domain.product.model.ProductOption;
+import org.son.sonstudy.domain.product.model.ProductStatus;
+import org.son.sonstudy.domain.product.repository.ProductOptionRepository;
+import org.son.sonstudy.domain.user.model.User;
+import org.son.sonstudy.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+    private final PaymentGateway paymentGateway;
+    private final PaymentRepository paymentRepository;
+    private final OrderRepository orderRepository;
+    private final UserRepository userRepository;
+    private final ProductOptionRepository productOptionRepository;
+
+    @Transactional
+    public CheckoutResponse checkout(String userId, CheckoutRequest request) {
+        Payment existingPayment = paymentRepository.findByMerchantUid(request.idempotencyKey()).orElse(null);
+        if (existingPayment != null) {
+            return toResponse(existingPayment);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        ProductOption productOption = productOptionRepository.findById(request.productOptionId())
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+
+        validateCheckoutRequest(userId, request, productOption);
+
+        Payment payment = Payment.createRequested(
+                request.idempotencyKey(),
+                request.paymentMethod(),
+                request.amount()
+        );
+        paymentRepository.save(payment);
+
+        PaymentGatewayResult gatewayResult = paymentGateway.approve(new PaymentApproveCommand(
+                request.idempotencyKey(),
+                request.paymentMethod(),
+                request.amount()
+        ));
+        if (!gatewayResult.success()) {
+            payment.markFailed(gatewayResult.failureCode(), gatewayResult.failureMessage());
+            paymentRepository.save(payment);
+            return toResponse(payment);
+        }
+
+        Order order = Order.createPurchased(user, productOption, Math.toIntExact(request.amount()));
+        orderRepository.save(order);
+
+        payment.attachOrder(order);
+        payment.markPaid(gatewayResult.pgTransactionId());
+        paymentRepository.save(payment);
+
+        return toResponse(payment);
+    }
+
+    private CheckoutResponse toResponse(Payment payment) {
+        Order order = payment.getOrder();
+        return new CheckoutResponse(
+                order != null ? order.getId() : null,
+                payment.getId(),
+                order != null ? order.getStatus() : null,
+                payment.getStatus(),
+                payment.getFailureCode(),
+                payment.getFailureMessage()
+        );
+    }
+
+    private void validateCheckoutRequest(String userId, CheckoutRequest request, ProductOption productOption) {
+        if (request.amount() != productOption.getCost()) {
+            throw new CustomException(ErrorCode.BAD_REQUEST);
+        }
+
+        if (productOption.getStatus() != ProductStatus.ON_SALE || productOption.getStock() < 1) {
+            throw new CustomException(ErrorCode.BAD_REQUEST);
+        }
+
+        if (orderRepository.existsByUserIdAndProductId(userId, productOption.getProduct().getId())) {
+            throw new CustomException(ErrorCode.BAD_REQUEST);
+        }
+    }
+}

--- a/src/main/java/org/son/sonstudy/domain/order/business/response/CheckoutResponse.java
+++ b/src/main/java/org/son/sonstudy/domain/order/business/response/CheckoutResponse.java
@@ -1,0 +1,14 @@
+package org.son.sonstudy.domain.order.business.response;
+
+import org.son.sonstudy.domain.order.model.OrderStatus;
+import org.son.sonstudy.domain.payment.model.PaymentStatus;
+
+public record CheckoutResponse(
+        String orderId,
+        String paymentId,
+        OrderStatus orderStatus,
+        PaymentStatus paymentStatus,
+        String failureCode,
+        String failureMessage
+) {
+}

--- a/src/main/java/org/son/sonstudy/domain/order/model/Order.java
+++ b/src/main/java/org/son/sonstudy/domain/order/model/Order.java
@@ -2,16 +2,25 @@ package org.son.sonstudy.domain.order.model;
 
 import io.hypersistence.utils.hibernate.id.Tsid;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.son.sonstudy.domain.delivery.model.Delivery;
 import org.son.sonstudy.domain.product.model.Product;
+import org.son.sonstudy.domain.product.model.ProductOption;
 import org.son.sonstudy.domain.user.model.User;
 
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "orders")
+@Getter
+@Table(
+        name = "orders",
+        indexes = {
+                @Index(name = "idx_orders_user_product", columnList = "user_id, product_id")
+        }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Order {
     @Id
@@ -26,6 +35,10 @@ public class Order {
     @JoinColumn(name = "product_id")
     private Product product;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_option_id")
+    private ProductOption productOption;
+
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "delivery_id")
     private Delivery delivery;
@@ -37,4 +50,26 @@ public class Order {
     private OrderStatus status;
 
     private LocalDateTime orderDate;
+
+    @Builder
+    private Order(User user, Product product, ProductOption productOption, Delivery delivery, int cost, OrderStatus status, LocalDateTime orderDate) {
+        this.user = user;
+        this.product = product;
+        this.productOption = productOption;
+        this.delivery = delivery;
+        this.cost = cost;
+        this.status = status;
+        this.orderDate = orderDate;
+    }
+
+    public static Order createPurchased(User user, ProductOption productOption, int cost) {
+        return Order.builder()
+                .user(user)
+                .product(productOption.getProduct())
+                .productOption(productOption)
+                .cost(cost)
+                .status(OrderStatus.PURCHASED)
+                .orderDate(LocalDateTime.now())
+                .build();
+    }
 }

--- a/src/main/java/org/son/sonstudy/domain/order/repository/OrderRepository.java
+++ b/src/main/java/org/son/sonstudy/domain/order/repository/OrderRepository.java
@@ -1,0 +1,8 @@
+package org.son.sonstudy.domain.order.repository;
+
+import org.son.sonstudy.domain.order.model.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, String> {
+    boolean existsByUserIdAndProductId(String userId, String productId);
+}

--- a/src/main/java/org/son/sonstudy/domain/payment/business/pg/FakePaymentGateway.java
+++ b/src/main/java/org/son/sonstudy/domain/payment/business/pg/FakePaymentGateway.java
@@ -1,0 +1,21 @@
+package org.son.sonstudy.domain.payment.business.pg;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class FakePaymentGateway implements PaymentGateway {
+
+    @Override
+    public PaymentGatewayResult approve(PaymentApproveCommand command) {
+        if (shouldFail(command.merchantUid())) {
+            return PaymentGatewayResult.fail("FAKE_PG_DECLINED", "Fake PG 결제 실패");
+        }
+
+        String pgTransactionId = "FAKE-PG-" + Integer.toUnsignedString(command.merchantUid().hashCode());
+        return PaymentGatewayResult.success(pgTransactionId);
+    }
+
+    private boolean shouldFail(String merchantUid) {
+        return merchantUid != null && merchantUid.toUpperCase().endsWith("FAIL");
+    }
+}

--- a/src/main/java/org/son/sonstudy/domain/payment/business/pg/PaymentApproveCommand.java
+++ b/src/main/java/org/son/sonstudy/domain/payment/business/pg/PaymentApproveCommand.java
@@ -1,0 +1,10 @@
+package org.son.sonstudy.domain.payment.business.pg;
+
+import org.son.sonstudy.domain.payment.model.PaymentMethod;
+
+public record PaymentApproveCommand(
+        String merchantUid,
+        PaymentMethod paymentMethod,
+        Long amount
+) {
+}

--- a/src/main/java/org/son/sonstudy/domain/payment/business/pg/PaymentGateway.java
+++ b/src/main/java/org/son/sonstudy/domain/payment/business/pg/PaymentGateway.java
@@ -1,0 +1,5 @@
+package org.son.sonstudy.domain.payment.business.pg;
+
+public interface PaymentGateway {
+    PaymentGatewayResult approve(PaymentApproveCommand command);
+}

--- a/src/main/java/org/son/sonstudy/domain/payment/business/pg/PaymentGatewayResult.java
+++ b/src/main/java/org/son/sonstudy/domain/payment/business/pg/PaymentGatewayResult.java
@@ -1,0 +1,16 @@
+package org.son.sonstudy.domain.payment.business.pg;
+
+public record PaymentGatewayResult(
+        boolean success,
+        String pgTransactionId,
+        String failureCode,
+        String failureMessage
+) {
+    public static PaymentGatewayResult success(String pgTransactionId) {
+        return new PaymentGatewayResult(true, pgTransactionId, null, null);
+    }
+
+    public static PaymentGatewayResult fail(String failureCode, String failureMessage) {
+        return new PaymentGatewayResult(false, null, failureCode, failureMessage);
+    }
+}

--- a/src/main/java/org/son/sonstudy/domain/payment/model/Payment.java
+++ b/src/main/java/org/son/sonstudy/domain/payment/model/Payment.java
@@ -1,0 +1,103 @@
+package org.son.sonstudy.domain.payment.model;
+
+import io.hypersistence.utils.hibernate.id.Tsid;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.son.sonstudy.domain.order.model.Order;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Entity
+@Getter
+@Table(name = "payment")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Payment {
+    @Id
+    @Tsid
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
+    private Order order;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String merchantUid;
+
+    @Column(length = 100)
+    private String pgTransactionId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private PaymentStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private PaymentMethod method;
+
+    @Column(nullable = false)
+    private Long amount;
+
+    @Column(length = 50)
+    private String failureCode;
+
+    @Column(length = 255)
+    private String failureMessage;
+
+    private LocalDateTime requestedAt;
+
+    private LocalDateTime approvedAt;
+
+    private LocalDateTime failedAt;
+
+    @Builder
+    private Payment(Order order, String merchantUid, PaymentMethod method, Long amount) {
+        this.order = order;
+        this.merchantUid = merchantUid;
+        this.method = method;
+        this.amount = amount;
+        this.status = PaymentStatus.REQUESTED;
+        this.requestedAt = LocalDateTime.now();
+    }
+
+    public static Payment createRequested(String merchantUid, PaymentMethod method, Long amount) {
+        return Payment.builder()
+                .merchantUid(merchantUid)
+                .method(method)
+                .amount(amount)
+                .build();
+    }
+
+    public static Payment createRequested(Order order, String merchantUid, PaymentMethod method, Long amount) {
+        return Payment.builder()
+                .order(order)
+                .merchantUid(merchantUid)
+                .method(method)
+                .amount(amount)
+                .build();
+    }
+
+    public void attachOrder(Order order) {
+        this.order = Objects.requireNonNull(order, "order must not be null");
+    }
+
+    public void markPaid(String pgTransactionId) {
+        this.status = PaymentStatus.PAID;
+        this.pgTransactionId = pgTransactionId;
+        this.approvedAt = LocalDateTime.now();
+        this.failedAt = null;
+        this.failureCode = null;
+        this.failureMessage = null;
+    }
+
+    public void markFailed(String failureCode, String failureMessage) {
+        this.status = PaymentStatus.FAILED;
+        this.failedAt = LocalDateTime.now();
+        this.failureCode = failureCode;
+        this.failureMessage = failureMessage;
+        this.approvedAt = null;
+    }
+}

--- a/src/main/java/org/son/sonstudy/domain/payment/model/PaymentMethod.java
+++ b/src/main/java/org/son/sonstudy/domain/payment/model/PaymentMethod.java
@@ -1,0 +1,8 @@
+package org.son.sonstudy.domain.payment.model;
+
+public enum PaymentMethod {
+    CARD,
+    ACCOUNT_TRANSFER,
+    VIRTUAL_ACCOUNT,
+    SIMPLE_PAY
+}

--- a/src/main/java/org/son/sonstudy/domain/payment/model/PaymentStatus.java
+++ b/src/main/java/org/son/sonstudy/domain/payment/model/PaymentStatus.java
@@ -1,0 +1,8 @@
+package org.son.sonstudy.domain.payment.model;
+
+public enum PaymentStatus {
+    REQUESTED,
+    PAID,
+    FAILED,
+    CANCELLED
+}

--- a/src/main/java/org/son/sonstudy/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/org/son/sonstudy/domain/payment/repository/PaymentRepository.java
@@ -1,0 +1,10 @@
+package org.son.sonstudy.domain.payment.repository;
+
+import org.son.sonstudy.domain.payment.model.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PaymentRepository extends JpaRepository<Payment, String> {
+    Optional<Payment> findByMerchantUid(String merchantUid);
+}

--- a/src/main/java/org/son/sonstudy/domain/product/repository/ProductOptionRepository.java
+++ b/src/main/java/org/son/sonstudy/domain/product/repository/ProductOptionRepository.java
@@ -6,8 +6,11 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ProductOptionRepository extends JpaRepository<ProductOption, String> {
+    Optional<ProductOption> findById(String id);
+
     List<ProductOption> findByProductId(String productId);
 
     @Query("SELECT po FROM ProductOption po WHERE po.product.id IN :productIds")


### PR DESCRIPTION
## 📌 Issue
<!-- 관련 이슈 번호 -->
- closed #30

## ✍️ Summary
<!-- 이슈에 대한 설명 -->

### 주문 확정 API Flow
PG에 결제 요청 -> 결제 성공 시: Payment, Order생성 및 저장 / 실패 시: Payment 생성 및 저장 Order 저장 X
Payment와 Order의 생성을 하나의 트랙잭션으로 구성했습니다.

### Payment
- id: 결제 엔티티 내부 PK
- order: 
- merchantUid: 내부 멱등/중복방지용 결제 요청 키 (대부분의 PG사에서 요청할 때 필요하다고 함)
- pgTransactionId: PG에서 발급한 거래 식별자
- status: 결제 상태 (REQUESTED, PAID, FAILED, ...)
- method: 결제 수단 (CARD, ACCOUNT_TRANSFER 등)
- amount: 결제 금액
- failureCode: 실패 원인 코드
- failureMessage: 실패 상세 메시지
- requestedAt: 결제 요청 시각
- approvedAt: 결제 승인 시각
- failedAt: 결제 실패 시각

### CheckoutRequest
- productOptionId: 구매할 상품 옵션 ID
- paymentMethod: 결제 수단(예: CARD, ACCOUNT_TRANSFER)
- amount: 클라이언트가 인지한 결제 금액
- idempotencyKey: 같은 결제 요청의 중복 처리 방지 키 -> payment의 merchantUid 값으로 들어감



## 📢 Notify
<!-- 리뷰어 참고 사항-->
대부분의 드랍 플랫폼에서 구매 상품 수량을 1개로 제한해두고 있으므로 주문 엔티티에 수량 필드는 추가 안했습니다.

추후 미니 PG서버 구현 예정이므로 PG역할을 하는 FakePaymentGateway클래스를 임시 구현해두었습니다.
규칙: idempotencyKey(멱등성 키)가 FAIL로 끝나면 실패, 그 외 성공
성공 시 가짜 pgTransactionId 반환, 실패 시 failureCode/failureMessage 반환

**아직 delievery로 이어지는 로직은 아닙니다~**