### PR TITLE
Feat/#29 브랜드 별 조회 구현

### DIFF
--- a/src/main/java/org/son/sonstudy/domain/product/application/ProductController.java
+++ b/src/main/java/org/son/sonstudy/domain/product/application/ProductController.java
@@ -14,6 +14,7 @@ import org.son.sonstudy.domain.product.business.response.ProductDetailResponse;
 import org.son.sonstudy.domain.product.business.response.ProductLiveResponse;
 import org.son.sonstudy.domain.product.business.response.ProductResponse;
 import org.son.sonstudy.domain.product.business.response.ScheduledDropsResponse;
+import org.son.sonstudy.domain.product.dto.ProductSearchFilter;
 import org.son.sonstudy.domain.product.model.ProductStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -40,15 +41,7 @@ public class ProductController {
 
         return ApiResponse.success(SuccessCode.PRODUCT_REGISTERED);
     }
-
-    @GetMapping
-    public ResponseEntity<ApiResponse<ProductResponse>> getAllProducts(
-            @PageableDefault(size = 10, sort = "releasedAt", direction = Sort.Direction.ASC) Pageable pageable
-    ) {
-        ProductResponse response = productService.findAllProducts(pageable);
-
-        return ApiResponse.success(SuccessCode.PRODUCT_OK, response);
-    }
+    
 
     @GetMapping("/{productId}")
     public ResponseEntity<ApiResponse<ProductDetailResponse>> getProductDetail(
@@ -85,14 +78,13 @@ public class ProductController {
         return ApiResponse.success(SuccessCode.PRODUCT_OK, response);
     }
 
-    @GetMapping("/brand")
-    public ResponseEntity<ApiResponse<ProductResponse>> getProductsByBrand(
-            @RequestParam String brand,
+    @GetMapping
+    public ResponseEntity<ApiResponse<ProductResponse>> getProducts(
+            ProductSearchFilter filter,
             @PageableDefault(size = 10, sort = "releasedAt", direction = Sort.Direction.ASC) Pageable pageable
-    ) {
-        ProductResponse response = productService.findAllProductsByBrand(brand, pageable);
+    ){
+        ProductResponse response = productService.findProducts(filter, pageable);
 
         return ApiResponse.success(SuccessCode.PRODUCT_OK, response);
-
     }
 }

--- a/src/main/java/org/son/sonstudy/domain/product/application/ProductController.java
+++ b/src/main/java/org/son/sonstudy/domain/product/application/ProductController.java
@@ -84,4 +84,15 @@ public class ProductController {
         ProductLiveResponse response = productService.findLiveDrops(userId, pageable);
         return ApiResponse.success(SuccessCode.PRODUCT_OK, response);
     }
+
+    @GetMapping("/brand")
+    public ResponseEntity<ApiResponse<ProductResponse>> getProductsByBrand(
+            @RequestParam String brand,
+            @PageableDefault(size = 10, sort = "releasedAt", direction = Sort.Direction.ASC) Pageable pageable
+    ) {
+        ProductResponse response = productService.findAllProductsByBrand(brand, pageable);
+
+        return ApiResponse.success(SuccessCode.PRODUCT_OK, response);
+
+    }
 }

--- a/src/main/java/org/son/sonstudy/domain/product/application/ProductController.java
+++ b/src/main/java/org/son/sonstudy/domain/product/application/ProductController.java
@@ -81,7 +81,7 @@ public class ProductController {
     @GetMapping
     public ResponseEntity<ApiResponse<ProductResponse>> getProducts(
             ProductSearchFilter filter,
-            @PageableDefault(size = 10, sort = "releasedAt", direction = Sort.Direction.ASC) Pageable pageable
+            @PageableDefault(size = 10, sort = "releasedAt", direction = Sort.Direction.DESC) Pageable pageable
     ){
         ProductResponse response = productService.findProducts(filter, pageable);
 

--- a/src/main/java/org/son/sonstudy/domain/product/business/ProductService.java
+++ b/src/main/java/org/son/sonstudy/domain/product/business/ProductService.java
@@ -14,6 +14,8 @@ public interface ProductService {
 
     ProductResponse findAllProducts(Pageable pageable);
 
+    ProductResponse findAllProductsByBrand(String brand, Pageable pageable);
+
     ProductDetailResponse findProductDetail(String productId);
 
     ScheduledDropsResponse findScheduledDrops(String userId, ScheduledDropsRequest request);

--- a/src/main/java/org/son/sonstudy/domain/product/business/ProductService.java
+++ b/src/main/java/org/son/sonstudy/domain/product/business/ProductService.java
@@ -6,15 +6,15 @@ import org.son.sonstudy.domain.product.business.response.ProductDetailResponse;
 import org.son.sonstudy.domain.product.business.response.ProductLiveResponse;
 import org.son.sonstudy.domain.product.business.response.ProductResponse;
 import org.son.sonstudy.domain.product.business.response.ScheduledDropsResponse;
+import org.son.sonstudy.domain.product.dto.ProductSearchFilter;
+import org.son.sonstudy.domain.product.repository.ProductRepository;
 import org.springframework.data.domain.Pageable;
 
 public interface ProductService {
 
     void register(String userId, ProductRegistrationRequest request);
 
-    ProductResponse findAllProducts(Pageable pageable);
-
-    ProductResponse findAllProductsByBrand(String brand, Pageable pageable);
+    ProductResponse findProducts(ProductSearchFilter filter, Pageable pageable);
 
     ProductDetailResponse findProductDetail(String productId);
 

--- a/src/main/java/org/son/sonstudy/domain/product/business/ProductServiceImpl.java
+++ b/src/main/java/org/son/sonstudy/domain/product/business/ProductServiceImpl.java
@@ -90,6 +90,14 @@ public class ProductServiceImpl implements ProductService {
 
     @Override
     @Transactional(readOnly = true)
+    public ProductResponse findAllProductsByBrand(String brand, Pageable pageable) {
+        Page<Product> products = productRepository.findByBrandIgnoreCase(brand, pageable);
+
+        return ProductResponse.from(products);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public ProductDetailResponse findProductDetail(String productId) {
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));

--- a/src/main/java/org/son/sonstudy/domain/product/business/ProductServiceImpl.java
+++ b/src/main/java/org/son/sonstudy/domain/product/business/ProductServiceImpl.java
@@ -9,6 +9,7 @@ import org.son.sonstudy.domain.product.business.response.ProductDetailResponse;
 import org.son.sonstudy.domain.product.business.response.ProductLiveResponse;
 import org.son.sonstudy.domain.product.business.response.ProductResponse;
 import org.son.sonstudy.domain.product.business.response.ScheduledDropsResponse;
+import org.son.sonstudy.domain.product.dto.ProductSearchFilter;
 import org.son.sonstudy.domain.product.model.Product;
 import org.son.sonstudy.domain.product.model.ProductOption;
 import org.son.sonstudy.domain.product.model.ProductStatus;
@@ -81,21 +82,15 @@ public class ProductServiceImpl implements ProductService {
         }
     }
 
+
     @Override
     @Transactional(readOnly = true)
-    public ProductResponse findAllProducts(Pageable pageable) {
-        Page<Product> products = productRepository.findAll(pageable);
+    public ProductResponse findProducts(ProductSearchFilter filter, Pageable pageable){
+        Page<Product> products = productRepository.findProductsByFilter(filter, pageable);
 
         return ProductResponse.from(products);
     }
 
-    @Override
-    @Transactional(readOnly = true)
-    public ProductResponse findAllProductsByBrand(String brand, Pageable pageable) {
-        Page<Product> products = productRepository.findByBrandIgnoreCase(brand, ProductStatus.ON_SALE, pageable);
-
-        return ProductResponse.from(products);
-    }
 
     @Override
     @Transactional(readOnly = true)

--- a/src/main/java/org/son/sonstudy/domain/product/business/ProductServiceImpl.java
+++ b/src/main/java/org/son/sonstudy/domain/product/business/ProductServiceImpl.java
@@ -11,6 +11,7 @@ import org.son.sonstudy.domain.product.business.response.ProductResponse;
 import org.son.sonstudy.domain.product.business.response.ScheduledDropsResponse;
 import org.son.sonstudy.domain.product.model.Product;
 import org.son.sonstudy.domain.product.model.ProductOption;
+import org.son.sonstudy.domain.product.model.ProductStatus;
 import org.son.sonstudy.domain.product.model.submodel.Color;
 import org.son.sonstudy.domain.product.model.submodel.ColorRepository;
 import org.son.sonstudy.domain.product.model.submodel.ProductImage;
@@ -91,7 +92,7 @@ public class ProductServiceImpl implements ProductService {
     @Override
     @Transactional(readOnly = true)
     public ProductResponse findAllProductsByBrand(String brand, Pageable pageable) {
-        Page<Product> products = productRepository.findByBrandIgnoreCase(brand, pageable);
+        Page<Product> products = productRepository.findByBrandIgnoreCase(brand, ProductStatus.ON_SALE, pageable);
 
         return ProductResponse.from(products);
     }

--- a/src/main/java/org/son/sonstudy/domain/product/dto/ProductSearchFilter.java
+++ b/src/main/java/org/son/sonstudy/domain/product/dto/ProductSearchFilter.java
@@ -8,3 +8,4 @@ public record ProductSearchFilter(
 ){
 
 }
+    

--- a/src/main/java/org/son/sonstudy/domain/product/dto/ProductSearchFilter.java
+++ b/src/main/java/org/son/sonstudy/domain/product/dto/ProductSearchFilter.java
@@ -1,0 +1,10 @@
+package org.son.sonstudy.domain.product.dto;
+
+import org.son.sonstudy.domain.product.model.ProductStatus;
+
+public record ProductSearchFilter(
+        String brand,
+        ProductStatus status
+){
+
+}

--- a/src/main/java/org/son/sonstudy/domain/product/repository/ProductRepository.java
+++ b/src/main/java/org/son/sonstudy/domain/product/repository/ProductRepository.java
@@ -9,11 +9,5 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ProductRepository extends JpaRepository<Product, String>, ProductRepositoryCustom {
-    @Query("""
-            select p
-            from Product p
-            where upper(p.brand) = upper(:brand)
-            and p.status = :status
-            """)
-    Page<Product> findByBrandIgnoreCase(@Param("brand") String brand, @Param("status") ProductStatus status, Pageable pageable);
+
 }

--- a/src/main/java/org/son/sonstudy/domain/product/repository/ProductRepository.java
+++ b/src/main/java/org/son/sonstudy/domain/product/repository/ProductRepository.java
@@ -1,10 +1,19 @@
 package org.son.sonstudy.domain.product.repository;
 
 import org.son.sonstudy.domain.product.model.Product;
+import org.son.sonstudy.domain.product.model.ProductStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProductRepository extends JpaRepository<Product, String>, ProductRepositoryCustom {
-    Page<Product> findByBrandIgnoreCase(String brand, Pageable pageable);
+    @Query("""
+            select p
+            from Product p
+            where upper(p.brand) = upper(:brand)
+            and p.status = :status
+            """)
+    Page<Product> findByBrandIgnoreCase(@Param("brand") String brand, @Param("status") ProductStatus status, Pageable pageable);
 }

--- a/src/main/java/org/son/sonstudy/domain/product/repository/ProductRepository.java
+++ b/src/main/java/org/son/sonstudy/domain/product/repository/ProductRepository.java
@@ -2,6 +2,9 @@ package org.son.sonstudy.domain.product.repository;
 
 import org.son.sonstudy.domain.product.model.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface ProductRepository extends JpaRepository<Product, String>, ProductRepositoryCustom {
+    Page<Product> findByBrandIgnoreCase(String brand, Pageable pageable);
 }

--- a/src/main/java/org/son/sonstudy/domain/product/repository/ProductRepositoryCustom.java
+++ b/src/main/java/org/son/sonstudy/domain/product/repository/ProductRepositoryCustom.java
@@ -1,6 +1,8 @@
 package org.son.sonstudy.domain.product.repository;
 
+import org.son.sonstudy.domain.product.dto.ProductSearchFilter;
 import org.son.sonstudy.domain.product.model.Product;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
@@ -11,4 +13,6 @@ public interface ProductRepositoryCustom {
     List<Product> findScheduledDropsByCursor(LocalDateTime cursorReleasedAt, String cursorId, int size);
 
     Slice<Product> findLiveDrops(String userId, Pageable pageable);
+
+    Page<Product> findProductsByFilter(ProductSearchFilter filter, Pageable pageable);
 }

--- a/src/main/java/org/son/sonstudy/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/org/son/sonstudy/domain/product/repository/ProductRepositoryImpl.java
@@ -3,13 +3,14 @@ package org.son.sonstudy.domain.product.repository;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.util.StringUtils;
+import org.son.sonstudy.domain.product.dto.ProductSearchFilter;
 import org.son.sonstudy.domain.product.model.*;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -87,6 +88,33 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
         return new SliceImpl<>(content, pageable, hasNext);
     }
 
+    @Override
+    public Page<Product> findProductsByFilter(ProductSearchFilter filter, Pageable pageable){
+        QProduct product = QProduct.product;
+
+        List<Product> content = queryFactory
+                .selectFrom(product)
+                .where(
+                        brandEq(filter.brand()),
+                        statusEq(filter.status())
+                )
+                .orderBy(product.releasedAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(product.count())
+                .from(product)
+                .where(
+                        brandEq(filter.brand()),
+                        statusEq(filter.status())
+                )
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
     private BooleanBuilder buildCursorPredicate(
             QProduct product,
             LocalDateTime cursorReleasedAt,
@@ -101,5 +129,13 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
             );
         }
         return builder;
+    }
+
+    private BooleanExpression brandEq(String brand) {
+        return StringUtils.hasText(brand) ? QProduct.product.brand.equalsIgnoreCase(brand) : null;
+    }
+
+    private BooleanExpression statusEq(ProductStatus status) {
+        return status != null ? QProduct.product.status.eq(status) : null;
     }
 }


### PR DESCRIPTION
## 📌 Issue
<!-- 관련 이슈 번호 -->
- closed #29 

## ✍️ Summary
<!-- 이슈에 대한 설명 -->
* 기존 조회 로직 기반으로 브랜드 별 조회 구현
* 대소문자 구분 없이 브랜드 명을 조회 할 수 있도록 findByBrandIgnoreCase 메서드를 추가했습니다.
* ProductController에  /brand 엔드포인트를 추가하여 @RequestParam으로 브랜드명을 입력받도록 구현했습니다.

## 📢 Notify
<!-- 리뷰어 참고 사항-->
최대한 기존 로직에서 벗어나지 않는 방향으로 구현했습니다.