### PR TITLE
[feat/#33] 주문 조회 기능 구현

### DIFF
--- a/src/main/java/org/son/sonstudy/domain/delivery/model/Delivery.java
+++ b/src/main/java/org/son/sonstudy/domain/delivery/model/Delivery.java
@@ -25,4 +25,10 @@ public class Delivery {
 
     @Enumerated(EnumType.STRING)
     private DeliveryStatus status;
+
+    public static Delivery createReady() {
+        Delivery delivery = new Delivery();
+        delivery.status = DeliveryStatus.READY;
+        return delivery;
+    }
 }

--- a/src/main/java/org/son/sonstudy/domain/order/application/OrderController.java
+++ b/src/main/java/org/son/sonstudy/domain/order/application/OrderController.java
@@ -2,18 +2,22 @@ package org.son.sonstudy.domain.order.application;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.son.sonstudy.common.api.code.SuccessCode;
 import org.son.sonstudy.common.api.response.ApiResponse;
 import org.son.sonstudy.common.jwt.data.UserContext;
 import org.son.sonstudy.domain.order.application.request.CheckoutRequest;
+import org.son.sonstudy.domain.order.application.request.OrderHistoryRequest;
 import org.son.sonstudy.domain.order.business.OrderService;
 import org.son.sonstudy.domain.order.business.response.CheckoutResponse;
+import org.son.sonstudy.domain.order.business.response.OrderHistoryResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.son.sonstudy.common.api.code.SuccessCode;
 
 @RestController
 @RequestMapping("/api/orders")
@@ -21,6 +25,19 @@ import org.son.sonstudy.common.api.code.SuccessCode;
 public class OrderController {
 
     private final OrderService orderService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<OrderHistoryResponse>> getOrderHistory(
+            @AuthenticationPrincipal UserContext userContext,
+            @Valid @ModelAttribute OrderHistoryRequest request
+    ) {
+        OrderHistoryResponse response = orderService.getOrderHistory(
+                userContext.userId(),
+                request
+        );
+
+        return ApiResponse.success(SuccessCode.OK, response);
+    }
 
     @PostMapping("/checkout")
     public ResponseEntity<ApiResponse<CheckoutResponse>> checkout(

--- a/src/main/java/org/son/sonstudy/domain/order/application/request/OrderHistoryRequest.java
+++ b/src/main/java/org/son/sonstudy/domain/order/application/request/OrderHistoryRequest.java
@@ -1,0 +1,19 @@
+package org.son.sonstudy.domain.order.application.request;
+
+import jakarta.validation.constraints.Positive;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+public record OrderHistoryRequest(
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        LocalDateTime cursorOrderDate,
+        String cursorOrderId,
+        @Positive Integer size
+) {
+    private static final int DEFAULT_SIZE = 10;
+
+    public int sizeOrDefault() {
+        return size == null ? DEFAULT_SIZE : size;
+    }
+}

--- a/src/main/java/org/son/sonstudy/domain/order/business/OrderService.java
+++ b/src/main/java/org/son/sonstudy/domain/order/business/OrderService.java
@@ -3,14 +3,12 @@ package org.son.sonstudy.domain.order.business;
 import lombok.RequiredArgsConstructor;
 import org.son.sonstudy.common.api.code.ErrorCode;
 import org.son.sonstudy.common.exception.CustomException;
-import org.son.sonstudy.domain.delivery.model.DeliveryStatus;
 import org.son.sonstudy.domain.order.application.request.CheckoutRequest;
 import org.son.sonstudy.domain.order.application.request.OrderHistoryRequest;
 import org.son.sonstudy.domain.order.business.response.CheckoutResponse;
 import org.son.sonstudy.domain.order.business.response.OrderHistoryResponse;
 import org.son.sonstudy.domain.order.model.Order;
 import org.son.sonstudy.domain.order.repository.OrderRepository;
-import org.son.sonstudy.domain.order.repository.OrderRepositoryCustom;
 import org.son.sonstudy.domain.payment.business.pg.PaymentApproveCommand;
 import org.son.sonstudy.domain.payment.business.pg.PaymentGateway;
 import org.son.sonstudy.domain.payment.business.pg.PaymentGatewayResult;
@@ -39,38 +37,25 @@ public class OrderService {
     @Transactional(readOnly = true)
     public OrderHistoryResponse getOrderHistory(String userId, OrderHistoryRequest request) {
         int size = request.sizeOrDefault();
-        List<OrderRepositoryCustom.OrderHistoryRow> rows = orderRepository.findOrderHistoryByCursor(
+        List<OrderHistoryResponse.OrderHistoryItem> orderHistories = orderRepository.findOrderHistoryByCursor(
                 userId,
                 request.cursorOrderDate(),
                 request.cursorOrderId(),
                 size
         );
-
-        boolean hasNext = rows.size() > size;
-        List<OrderRepositoryCustom.OrderHistoryRow> contentRows = hasNext ? rows.subList(0, size) : rows;
-        List<OrderHistoryResponse.OrderHistoryItem> content = contentRows.stream()
-                .map(row -> OrderHistoryResponse.OrderHistoryItem.of(
-                        row.orderId(),
-                        row.orderedAt(),
-                        row.orderStatus(),
-                        row.productName(),
-                        row.productImageUrl(),
-                        row.size(),
-                        row.amount(),
-                        row.deliveryStatus() != null ? row.deliveryStatus() : DeliveryStatus.READY,
-                        row.trackingNumber()
-                ))
-                .toList();
+        
+        boolean hasNext = orderHistories.size() > size;
+        List<OrderHistoryResponse.OrderHistoryItem> orderHistoryRows = hasNext ? orderHistories.subList(0, size) : orderHistories;
 
         LocalDateTime nextCursorOrderDate = null;
         String nextCursorOrderId = null;
-        if (hasNext && !contentRows.isEmpty()) {
-            OrderRepositoryCustom.OrderHistoryRow last = contentRows.get(contentRows.size() - 1);
+        if (hasNext && !orderHistoryRows.isEmpty()) {
+            OrderHistoryResponse.OrderHistoryItem last = orderHistoryRows.get(orderHistoryRows.size() - 1);
             nextCursorOrderDate = last.orderedAt();
             nextCursorOrderId = last.orderId();
         }
 
-        return OrderHistoryResponse.of(content, nextCursorOrderDate, nextCursorOrderId, hasNext);
+        return OrderHistoryResponse.of(orderHistoryRows, nextCursorOrderDate, nextCursorOrderId, hasNext);
     }
 
     @Transactional

--- a/src/main/java/org/son/sonstudy/domain/order/business/OrderService.java
+++ b/src/main/java/org/son/sonstudy/domain/order/business/OrderService.java
@@ -3,10 +3,14 @@ package org.son.sonstudy.domain.order.business;
 import lombok.RequiredArgsConstructor;
 import org.son.sonstudy.common.api.code.ErrorCode;
 import org.son.sonstudy.common.exception.CustomException;
+import org.son.sonstudy.domain.delivery.model.DeliveryStatus;
 import org.son.sonstudy.domain.order.application.request.CheckoutRequest;
+import org.son.sonstudy.domain.order.application.request.OrderHistoryRequest;
 import org.son.sonstudy.domain.order.business.response.CheckoutResponse;
+import org.son.sonstudy.domain.order.business.response.OrderHistoryResponse;
 import org.son.sonstudy.domain.order.model.Order;
 import org.son.sonstudy.domain.order.repository.OrderRepository;
+import org.son.sonstudy.domain.order.repository.OrderRepositoryCustom;
 import org.son.sonstudy.domain.payment.business.pg.PaymentApproveCommand;
 import org.son.sonstudy.domain.payment.business.pg.PaymentGateway;
 import org.son.sonstudy.domain.payment.business.pg.PaymentGatewayResult;
@@ -20,6 +24,9 @@ import org.son.sonstudy.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class OrderService {
@@ -28,6 +35,43 @@ public class OrderService {
     private final OrderRepository orderRepository;
     private final UserRepository userRepository;
     private final ProductOptionRepository productOptionRepository;
+
+    @Transactional(readOnly = true)
+    public OrderHistoryResponse getOrderHistory(String userId, OrderHistoryRequest request) {
+        int size = request.sizeOrDefault();
+        List<OrderRepositoryCustom.OrderHistoryRow> rows = orderRepository.findOrderHistoryByCursor(
+                userId,
+                request.cursorOrderDate(),
+                request.cursorOrderId(),
+                size
+        );
+
+        boolean hasNext = rows.size() > size;
+        List<OrderRepositoryCustom.OrderHistoryRow> contentRows = hasNext ? rows.subList(0, size) : rows;
+        List<OrderHistoryResponse.OrderHistoryItem> content = contentRows.stream()
+                .map(row -> OrderHistoryResponse.OrderHistoryItem.of(
+                        row.orderId(),
+                        row.orderedAt(),
+                        row.orderStatus(),
+                        row.productName(),
+                        row.productImageUrl(),
+                        row.size(),
+                        row.amount(),
+                        row.deliveryStatus() != null ? row.deliveryStatus() : DeliveryStatus.READY,
+                        row.trackingNumber()
+                ))
+                .toList();
+
+        LocalDateTime nextCursorOrderDate = null;
+        String nextCursorOrderId = null;
+        if (hasNext && !contentRows.isEmpty()) {
+            OrderRepositoryCustom.OrderHistoryRow last = contentRows.get(contentRows.size() - 1);
+            nextCursorOrderDate = last.orderedAt();
+            nextCursorOrderId = last.orderId();
+        }
+
+        return OrderHistoryResponse.of(content, nextCursorOrderDate, nextCursorOrderId, hasNext);
+    }
 
     @Transactional
     public CheckoutResponse checkout(String userId, CheckoutRequest request) {

--- a/src/main/java/org/son/sonstudy/domain/order/business/response/OrderHistoryResponse.java
+++ b/src/main/java/org/son/sonstudy/domain/order/business/response/OrderHistoryResponse.java
@@ -1,0 +1,59 @@
+package org.son.sonstudy.domain.order.business.response;
+
+import org.son.sonstudy.domain.delivery.model.DeliveryStatus;
+import org.son.sonstudy.domain.order.model.OrderStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record OrderHistoryResponse(
+        List<OrderHistoryItem> content,
+        LocalDateTime nextCursorOrderDate,
+        String nextCursorOrderId,
+        boolean hasNext
+) {
+    public static OrderHistoryResponse of(
+            List<OrderHistoryItem> content,
+            LocalDateTime nextCursorOrderDate,
+            String nextCursorOrderId,
+            boolean hasNext
+    ) {
+        return new OrderHistoryResponse(content, nextCursorOrderDate, nextCursorOrderId, hasNext);
+    }
+
+    public record OrderHistoryItem(
+            String orderId,
+            LocalDateTime orderedAt,
+            OrderStatus orderStatus,
+            String productName,
+            String productImageUrl,
+            int size,
+            long amount,
+            DeliveryStatus deliveryStatus,
+            String trackingNumber
+    ) {
+        public static OrderHistoryItem of(
+                String orderId,
+                LocalDateTime orderedAt,
+                OrderStatus orderStatus,
+                String productName,
+                String productImageUrl,
+                int size,
+                long amount,
+                DeliveryStatus deliveryStatus,
+                String trackingNumber
+        ) {
+            return new OrderHistoryItem(
+                    orderId,
+                    orderedAt,
+                    orderStatus,
+                    productName,
+                    productImageUrl,
+                    size,
+                    amount,
+                    deliveryStatus,
+                    trackingNumber
+            );
+        }
+    }
+}

--- a/src/main/java/org/son/sonstudy/domain/order/model/Order.java
+++ b/src/main/java/org/son/sonstudy/domain/order/model/Order.java
@@ -67,6 +67,7 @@ public class Order {
                 .user(user)
                 .product(productOption.getProduct())
                 .productOption(productOption)
+                .delivery(Delivery.createReady())
                 .cost(cost)
                 .status(OrderStatus.PURCHASED)
                 .orderDate(LocalDateTime.now())

--- a/src/main/java/org/son/sonstudy/domain/order/repository/OrderRepository.java
+++ b/src/main/java/org/son/sonstudy/domain/order/repository/OrderRepository.java
@@ -3,6 +3,6 @@ package org.son.sonstudy.domain.order.repository;
 import org.son.sonstudy.domain.order.model.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface OrderRepository extends JpaRepository<Order, String> {
+public interface OrderRepository extends JpaRepository<Order, String>, OrderRepositoryCustom {
     boolean existsByUserIdAndProductId(String userId, String productId);
 }

--- a/src/main/java/org/son/sonstudy/domain/order/repository/OrderRepositoryCustom.java
+++ b/src/main/java/org/son/sonstudy/domain/order/repository/OrderRepositoryCustom.java
@@ -1,0 +1,29 @@
+package org.son.sonstudy.domain.order.repository;
+
+import org.son.sonstudy.domain.delivery.model.DeliveryStatus;
+import org.son.sonstudy.domain.order.model.OrderStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface OrderRepositoryCustom {
+    List<OrderHistoryRow> findOrderHistoryByCursor(
+            String userId,
+            LocalDateTime cursorOrderDate,
+            String cursorOrderId,
+            int size
+    );
+
+    record OrderHistoryRow(
+            String orderId,
+            LocalDateTime orderedAt,
+            OrderStatus orderStatus,
+            String productName,
+            String productImageUrl,
+            int size,
+            long amount,
+            DeliveryStatus deliveryStatus,
+            String trackingNumber
+    ) {
+    }
+}

--- a/src/main/java/org/son/sonstudy/domain/order/repository/OrderRepositoryCustom.java
+++ b/src/main/java/org/son/sonstudy/domain/order/repository/OrderRepositoryCustom.java
@@ -1,29 +1,15 @@
 package org.son.sonstudy.domain.order.repository;
 
-import org.son.sonstudy.domain.delivery.model.DeliveryStatus;
-import org.son.sonstudy.domain.order.model.OrderStatus;
+import org.son.sonstudy.domain.order.business.response.OrderHistoryResponse;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface OrderRepositoryCustom {
-    List<OrderHistoryRow> findOrderHistoryByCursor(
+    List<OrderHistoryResponse.OrderHistoryItem> findOrderHistoryByCursor(
             String userId,
             LocalDateTime cursorOrderDate,
             String cursorOrderId,
             int size
     );
-
-    record OrderHistoryRow(
-            String orderId,
-            LocalDateTime orderedAt,
-            OrderStatus orderStatus,
-            String productName,
-            String productImageUrl,
-            int size,
-            long amount,
-            DeliveryStatus deliveryStatus,
-            String trackingNumber
-    ) {
-    }
 }

--- a/src/main/java/org/son/sonstudy/domain/order/repository/OrderRepositoryImpl.java
+++ b/src/main/java/org/son/sonstudy/domain/order/repository/OrderRepositoryImpl.java
@@ -1,0 +1,85 @@
+package org.son.sonstudy.domain.order.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.son.sonstudy.domain.delivery.model.Delivery;
+import org.son.sonstudy.domain.order.model.Order;
+import org.son.sonstudy.domain.product.model.Product;
+import org.son.sonstudy.domain.product.model.ProductOption;
+import org.son.sonstudy.domain.product.model.submodel.ProductImage;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderRepositoryImpl implements OrderRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<OrderHistoryRow> findOrderHistoryByCursor(
+            String userId,
+            LocalDateTime cursorOrderDate,
+            String cursorOrderId,
+            int size
+    ) {
+        PathBuilder<Order> order = new PathBuilder<>(Order.class, "order");
+        PathBuilder<Product> product = new PathBuilder<>(Product.class, "product");
+        PathBuilder<ProductOption> option = new PathBuilder<>(ProductOption.class, "option");
+        PathBuilder<Delivery> delivery = new PathBuilder<>(Delivery.class, "delivery");
+        PathBuilder<ProductImage> productImage = new PathBuilder<>(ProductImage.class, "productImage");
+
+        return queryFactory
+                .select(Projections.constructor(
+                        OrderHistoryRow.class,
+                        order.getString("id"),
+                        order.getDateTime("orderDate", LocalDateTime.class),
+                        order.getEnum("status", org.son.sonstudy.domain.order.model.OrderStatus.class),
+                        product.getString("name"),
+                        productImage.getString("imageUrl"),
+                        option.getNumber("size", Integer.class),
+                        order.getNumber("cost", Integer.class).longValue(),
+                        delivery.getEnum("status", org.son.sonstudy.domain.delivery.model.DeliveryStatus.class),
+                        delivery.getString("trackingNumber")
+                ))
+                .from(order)
+                .join(order.get("product", Product.class), product)
+                .join(order.get("productOption", ProductOption.class), option)
+                .leftJoin(order.get("delivery", Delivery.class), delivery)
+                .leftJoin(product.getList("images", ProductImage.class), productImage)
+                .on(productImage.getNumber("orders", Integer.class).eq(0))
+                .where(
+                        order.get("user").getString("id").eq(userId),
+                        buildCursorPredicate(order, cursorOrderDate, cursorOrderId)
+                )
+                .orderBy(
+                        order.getDateTime("orderDate", LocalDateTime.class).desc(),
+                        order.getString("id").desc()
+                )
+                .limit(size + 1L)
+                .fetch();
+    }
+
+    private BooleanBuilder buildCursorPredicate(
+            PathBuilder<Order> order,
+            LocalDateTime cursorOrderDate,
+            String cursorOrderId
+    ) {
+        BooleanBuilder builder = new BooleanBuilder();
+        var orderDate = order.getDateTime("orderDate", LocalDateTime.class);
+        var orderId = order.getString("id");
+        if (cursorOrderDate != null && cursorOrderId != null) {
+            builder.and(
+                    orderDate.lt(cursorOrderDate)
+                            .or(orderDate.eq(cursorOrderDate)
+                                    .and(orderId.lt(cursorOrderId)))
+            );
+        }
+        return builder;
+    }
+}

--- a/src/main/java/org/son/sonstudy/domain/order/repository/OrderRepositoryImpl.java
+++ b/src/main/java/org/son/sonstudy/domain/order/repository/OrderRepositoryImpl.java
@@ -1,11 +1,14 @@
 package org.son.sonstudy.domain.order.repository;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.son.sonstudy.domain.delivery.model.Delivery;
+import org.son.sonstudy.domain.delivery.model.DeliveryStatus;
+import org.son.sonstudy.domain.order.business.response.OrderHistoryResponse;
 import org.son.sonstudy.domain.order.model.Order;
 import org.son.sonstudy.domain.product.model.Product;
 import org.son.sonstudy.domain.product.model.ProductOption;
@@ -22,7 +25,7 @@ public class OrderRepositoryImpl implements OrderRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<OrderHistoryRow> findOrderHistoryByCursor(
+    public List<OrderHistoryResponse.OrderHistoryItem> findOrderHistoryByCursor(
             String userId,
             LocalDateTime cursorOrderDate,
             String cursorOrderId,
@@ -36,7 +39,7 @@ public class OrderRepositoryImpl implements OrderRepositoryCustom {
 
         return queryFactory
                 .select(Projections.constructor(
-                        OrderHistoryRow.class,
+                        OrderHistoryResponse.OrderHistoryItem.class,
                         order.getString("id"),
                         order.getDateTime("orderDate", LocalDateTime.class),
                         order.getEnum("status", org.son.sonstudy.domain.order.model.OrderStatus.class),
@@ -44,7 +47,10 @@ public class OrderRepositoryImpl implements OrderRepositoryCustom {
                         productImage.getString("imageUrl"),
                         option.getNumber("size", Integer.class),
                         order.getNumber("cost", Integer.class).longValue(),
-                        delivery.getEnum("status", org.son.sonstudy.domain.delivery.model.DeliveryStatus.class),
+                        new CaseBuilder()
+                                .when(delivery.getEnum("status", DeliveryStatus.class).isNull())
+                                .then(DeliveryStatus.READY)
+                                .otherwise(delivery.getEnum("status", DeliveryStatus.class)),
                         delivery.getString("trackingNumber")
                 ))
                 .from(order)


### PR DESCRIPTION
## 📌 Issue
<!-- 관련 이슈 번호 -->
- closed #33 

## ✍️ Summary
<!-- 이슈에 대한 설명 -->
주문 조회 기능 구현
- QueryDsl 커서 기반 조회
- 요청 예시
```
curl -X GET "http://localhost:8080/api/orders?cursorOrderDate=2026-03-09T14:20:33&cursorOrderId=01JNZ8ABCDEF1234567890&size=10" \
  -H "Authorization: Bearer <ACCESS_TOKEN>"
```
- 응답 예시
```
{
  "code": "DC200_001",
  "message": "요청 성공",
  "data": {
    "content": [
      {
        "orderId": "01JNZ8ZZZZZZZZZZZZZZZZ",
        "orderedAt": "2026-03-09T15:01:12",
        "orderStatus": "PURCHASED",
        "productName": "AIR RUNNER",
        "productImageUrl": "https://cdn.example.com/products/p1-main.jpg",
        "size": 270,
        "amount": 159000,
        "deliveryStatus": "READY",
        "trackingNumber": null
      }
    ],
    "nextCursorOrderDate": "2026-03-09T15:01:12",
    "nextCursorOrderId": "01JNZ8ZZZZZZZZZZZZZZZZ",
    "hasNext": true
  }
}
```

## 📢 Notify
<!-- 리뷰어 참고 사항-->
추후 작성하겠습니다.
