### PR TITLE
[Feat/#40] 배송상태 관리 구현

### DIFF
--- a/src/main/java/org/son/sonstudy/common/api/code/ErrorCode.java
+++ b/src/main/java/org/son/sonstudy/common/api/code/ErrorCode.java
@@ -38,7 +38,10 @@ public enum ErrorCode {
     INVALID_PRODUCT_SIZE("DC400_302", HttpStatus.BAD_REQUEST, "유효하지 않은 상품 사이즈입니다."),
     INVALID_STOCK("DC400_303", HttpStatus.BAD_REQUEST, "재고량은 음수가 될 수 없습니다."),
     INVALID_IMAGE_SIZE("DC400_304", HttpStatus.BAD_REQUEST, "상품 이미지는 1-10장 사이여야 합니다."),
-    INVALID_PRODUCT_STATE("DC400_305", HttpStatus.BAD_REQUEST , "상품 판매 상태가 정의되지 않았습니다." ),;
+    INVALID_PRODUCT_STATE("DC400_305", HttpStatus.BAD_REQUEST , "상품 판매 상태가 정의되지 않았습니다." ),
+
+    // DELIVERY
+    INVALID_DELIVERY_STATUS("DC400_501", HttpStatus.BAD_REQUEST, "현재 배송 상태에서는 해당 작업을 수행할 수 없습니다."),;
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/org/son/sonstudy/domain/delivery/application/DeliveryController.java
+++ b/src/main/java/org/son/sonstudy/domain/delivery/application/DeliveryController.java
@@ -1,0 +1,32 @@
+package org.son.sonstudy.domain.delivery.application;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.son.sonstudy.common.api.code.SuccessCode;
+import org.son.sonstudy.common.api.response.ApiResponse;
+import org.son.sonstudy.domain.delivery.application.request.DeliveryShipmentRequest;
+import org.son.sonstudy.domain.delivery.business.DeliveryService;
+import org.son.sonstudy.domain.delivery.business.response.DeliveryShipmentResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/deliveries")
+@RequiredArgsConstructor
+public class DeliveryController {
+
+    private final DeliveryService deliveryService;
+
+    @PutMapping("/orders/{orderId}/shipment")
+    public ResponseEntity<ApiResponse<DeliveryShipmentResponse>> registerShipment(
+            @PathVariable String orderId,
+            @RequestBody @Valid DeliveryShipmentRequest request
+    ) {
+        DeliveryShipmentResponse response = deliveryService.registerShipment(orderId, request);
+        return ApiResponse.success(SuccessCode.OK, response);
+    }
+}

--- a/src/main/java/org/son/sonstudy/domain/delivery/application/request/DeliveryShipmentRequest.java
+++ b/src/main/java/org/son/sonstudy/domain/delivery/application/request/DeliveryShipmentRequest.java
@@ -1,0 +1,12 @@
+package org.son.sonstudy.domain.delivery.application.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record DeliveryShipmentRequest(
+        @NotBlank(message = "택배사는 필수입니다.")
+        String courierCompany,
+
+        @NotBlank(message = "송장번호는 필수입니다.")
+        String trackingNumber
+) {
+}

--- a/src/main/java/org/son/sonstudy/domain/delivery/business/DeliveryService.java
+++ b/src/main/java/org/son/sonstudy/domain/delivery/business/DeliveryService.java
@@ -1,0 +1,30 @@
+package org.son.sonstudy.domain.delivery.business;
+
+import lombok.RequiredArgsConstructor;
+import org.son.sonstudy.common.api.code.ErrorCode;
+import org.son.sonstudy.common.exception.CustomException;
+import org.son.sonstudy.domain.delivery.application.request.DeliveryShipmentRequest;
+import org.son.sonstudy.domain.delivery.business.response.DeliveryShipmentResponse;
+import org.son.sonstudy.domain.delivery.model.Delivery;
+import org.son.sonstudy.domain.order.model.Order;
+import org.son.sonstudy.domain.order.repository.OrderRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryService {
+
+    private final OrderRepository orderRepository;
+
+    @Transactional
+    public DeliveryShipmentResponse registerShipment(String orderId, DeliveryShipmentRequest request) {
+        Order order = orderRepository.findWithDeliveryById(orderId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+
+        Delivery delivery = order.getDelivery();
+        delivery.registerShipment(request.courierCompany(), request.trackingNumber());
+
+        return DeliveryShipmentResponse.from(delivery);
+    }
+}

--- a/src/main/java/org/son/sonstudy/domain/delivery/business/DeliveryService.java
+++ b/src/main/java/org/son/sonstudy/domain/delivery/business/DeliveryService.java
@@ -5,7 +5,10 @@ import org.son.sonstudy.common.api.code.ErrorCode;
 import org.son.sonstudy.common.exception.CustomException;
 import org.son.sonstudy.domain.delivery.application.request.DeliveryShipmentRequest;
 import org.son.sonstudy.domain.delivery.business.response.DeliveryShipmentResponse;
+import org.son.sonstudy.domain.delivery.business.tracker.DeliveryTracker;
+import org.son.sonstudy.domain.delivery.business.tracker.DeliveryTrackingResult;
 import org.son.sonstudy.domain.delivery.model.Delivery;
+import org.son.sonstudy.domain.delivery.model.DeliveryStatus;
 import org.son.sonstudy.domain.order.model.Order;
 import org.son.sonstudy.domain.order.repository.OrderRepository;
 import org.springframework.stereotype.Service;
@@ -16,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DeliveryService {
 
     private final OrderRepository orderRepository;
+    private final DeliveryTracker deliveryTracker;
 
     @Transactional
     public DeliveryShipmentResponse registerShipment(String orderId, DeliveryShipmentRequest request) {
@@ -24,6 +28,28 @@ public class DeliveryService {
 
         Delivery delivery = order.getDelivery();
         delivery.registerShipment(request.courierCompany(), request.trackingNumber());
+
+        return DeliveryShipmentResponse.from(delivery);
+    }
+
+    @Transactional
+    public DeliveryShipmentResponse updateDeliveryStatus(String orderId) {
+        Order order = orderRepository.findWithDeliveryById(orderId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+
+        Delivery delivery = order.getDelivery();
+        if (delivery.getStatus() != DeliveryStatus.DELIVERING) {
+            throw new CustomException(ErrorCode.INVALID_DELIVERY_STATUS);
+        }
+
+        DeliveryTrackingResult result = deliveryTracker.track(
+                delivery.getCourierCompany(),
+                delivery.getTrackingNumber()
+        );
+
+        if (result.completed()) {
+            delivery.complete();
+        }
 
         return DeliveryShipmentResponse.from(delivery);
     }

--- a/src/main/java/org/son/sonstudy/domain/delivery/business/response/DeliveryShipmentResponse.java
+++ b/src/main/java/org/son/sonstudy/domain/delivery/business/response/DeliveryShipmentResponse.java
@@ -1,0 +1,20 @@
+package org.son.sonstudy.domain.delivery.business.response;
+
+import org.son.sonstudy.domain.delivery.model.Delivery;
+import org.son.sonstudy.domain.delivery.model.DeliveryStatus;
+
+public record DeliveryShipmentResponse(
+        String deliveryId,
+        String courierCompany,
+        String trackingNumber,
+        DeliveryStatus status
+) {
+    public static DeliveryShipmentResponse from(Delivery delivery) {
+        return new DeliveryShipmentResponse(
+                delivery.getId(),
+                delivery.getCourierCompany(),
+                delivery.getTrackingNumber(),
+                delivery.getStatus()
+        );
+    }
+}

--- a/src/main/java/org/son/sonstudy/domain/delivery/business/tracker/DeliveryTracker.java
+++ b/src/main/java/org/son/sonstudy/domain/delivery/business/tracker/DeliveryTracker.java
@@ -1,0 +1,5 @@
+package org.son.sonstudy.domain.delivery.business.tracker;
+
+public interface DeliveryTracker {
+    DeliveryTrackingResult track(String courierCode, String trackingNumber);
+}

--- a/src/main/java/org/son/sonstudy/domain/delivery/business/tracker/DeliveryTrackingResult.java
+++ b/src/main/java/org/son/sonstudy/domain/delivery/business/tracker/DeliveryTrackingResult.java
@@ -1,0 +1,10 @@
+package org.son.sonstudy.domain.delivery.business.tracker;
+
+public record DeliveryTrackingResult(
+        int level,
+        boolean completed,
+        String currentLocation,
+        String description
+) {
+    // level: 1=준비, 2=집화, 3=이동중, 4=지점도착, 5=배송출고, 6=완료, -99=오류
+}

--- a/src/main/java/org/son/sonstudy/domain/delivery/business/tracker/FakeDeliveryTracker.java
+++ b/src/main/java/org/son/sonstudy/domain/delivery/business/tracker/FakeDeliveryTracker.java
@@ -1,0 +1,27 @@
+package org.son.sonstudy.domain.delivery.business.tracker;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class FakeDeliveryTracker implements DeliveryTracker {
+
+    @Override
+    public DeliveryTrackingResult track(String courierCode, String trackingNumber) {
+        if (trackingNumber == null) {
+            return new DeliveryTrackingResult(-99, false, null, "송장번호 없음");
+        }
+
+        char lastChar = trackingNumber.charAt(trackingNumber.length() - 1);
+
+        return switch (lastChar) {
+            case '1' -> new DeliveryTrackingResult(1, false, "발송지", "배송 준비 중");
+            case '2' -> new DeliveryTrackingResult(2, false, "집화지점", "집화 완료");
+            case '3' -> new DeliveryTrackingResult(3, false, "옥천HUB", "배송 중");
+            case '4' -> new DeliveryTrackingResult(4, false, "강남지점", "지점 도착");
+            case '5' -> new DeliveryTrackingResult(5, false, "배송지 인근", "배송 출고");
+            case '6' -> new DeliveryTrackingResult(6, true, "수령인 자택", "배송 완료");
+            case '0' -> new DeliveryTrackingResult(-99, false, null, "스캔 오류");
+            default -> new DeliveryTrackingResult(3, false, "옥천HUB", "배송 중");
+        };
+    }
+}

--- a/src/main/java/org/son/sonstudy/domain/delivery/model/Delivery.java
+++ b/src/main/java/org/son/sonstudy/domain/delivery/model/Delivery.java
@@ -5,6 +5,8 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.son.sonstudy.common.api.code.ErrorCode;
+import org.son.sonstudy.common.exception.CustomException;
 
 @Entity
 @Getter
@@ -30,5 +32,14 @@ public class Delivery {
         Delivery delivery = new Delivery();
         delivery.status = DeliveryStatus.READY;
         return delivery;
+    }
+
+    public void registerShipment(String courierCompany, String trackingNumber) {
+        if (this.status != DeliveryStatus.READY) {
+            throw new CustomException(ErrorCode.INVALID_DELIVERY_STATUS);
+        }
+        this.courierCompany = courierCompany;
+        this.trackingNumber = trackingNumber;
+        this.status = DeliveryStatus.DELIVERING;
     }
 }

--- a/src/main/java/org/son/sonstudy/domain/delivery/model/Delivery.java
+++ b/src/main/java/org/son/sonstudy/domain/delivery/model/Delivery.java
@@ -42,4 +42,11 @@ public class Delivery {
         this.trackingNumber = trackingNumber;
         this.status = DeliveryStatus.DELIVERING;
     }
+
+    public void complete() {
+        if (this.status != DeliveryStatus.DELIVERING) {
+            throw new CustomException(ErrorCode.INVALID_DELIVERY_STATUS);
+        }
+        this.status = DeliveryStatus.DELIVERED;
+    }
 }

--- a/src/main/java/org/son/sonstudy/domain/order/repository/OrderRepository.java
+++ b/src/main/java/org/son/sonstudy/domain/order/repository/OrderRepository.java
@@ -2,7 +2,14 @@ package org.son.sonstudy.domain.order.repository;
 
 import org.son.sonstudy.domain.order.model.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, String>, OrderRepositoryCustom {
     boolean existsByUserIdAndProductId(String userId, String productId);
+
+    @Query("SELECT o FROM Order o JOIN FETCH o.delivery WHERE o.id = :orderId")
+    Optional<Order> findWithDeliveryById(@Param("orderId") String orderId);
 }


### PR DESCRIPTION
## 📌 Issue
<!-- 관련 이슈 번호 -->
- closed #40 

## ✍️ Summary
<!-- 이슈에 대한 설명 -->
Delivery는 주문의 배송 상태를 관리하는 도메인 엔티티입니다.
주문 생성 시 -> Delivery.createReady()로 READY 상태가 자동 생성됩니다.
출고 등록 시 -> registerShipment()가 호출되어 택배사/송장번호를 저장하고 상태를 DELIVERING으로 바꿉니다.
@PreAuthorize를 통해 1차적으로 ADMIN과 SELLER만 등록 가능하도록 해놓았으나, Product에 seller 정보 필드가 없어 판매자-상품 매칭 검증은 진행하지 않았습니다.

배송 완료-> complete()로 DELIVERED로 전환됩니다. 
각 메서드는 허용된 상태에서만 동작하도록 검증해 잘못된 상태 변경을 막습니다.

Tracker는 외부 배송 조회를 추상화한 인터페이스(DeliveryTracker)입니다.
서비스는 구현체를 직접 의존하지 않고 track(courierCode, trackingNumber)만 호출해 추적 결과를 받습니다. 
현재는 택배사 API 연동을 흉내낸 테스트용 FakeDeliveryTracker가 구현되어 있습니다.
Delivery는 상태를 책임지고, Tracker는 외부 조회를 책임지는 분리 구조입니다.
```
동작 방식
호출 메서드: track(courierCode, trackingNumber)
trackingNumber의 마지막 문자로 결과를 만듭니다.
1~5 -> 배송중(completed=false)
6 -> 배송완료(completed=true)
0 -> 오류 응답
null -> 송장번호 없음 오류 응답
즉, 송장번호 끝자리로 상태를 의도적으로 컨트롤할 수 있습니다.

실제 사용 흐름
먼저 출고 등록 API로 배송을 DELIVERING 상태로 만듭니다.
(PUT /api/deliveries/orders/{orderId}/shipment)
그다음 DeliveryService.updateDeliveryStatus(orderId)를 호출하면
내부에서 deliveryTracker.track(...) 실행
결과 completed=true면 delivery.complete() 호출
최종 상태가 DELIVERED로 바뀜
테스트할 때 팁
완료 처리 테스트: 송장번호를 ...6으로 넣기
배송중 유지 테스트: ...3 같은 값 사용
오류 케이스 테스트: ...0 또는 null 사용
```


## 📢 Notify
<!-- 리뷰어 참고 사항-->
### 트러블 슈팅 포인트
- 배송 상태 업데이트 API 노출 부족

DeliveryService.updateDeliveryStatus()는 있는데 DeliveryController에 매핑이 없음(현재는 출고 등록 API만 있음)
그래서 실제 운영에서 상태 동기화 트리거 경로가 불명확해질 수 있음(스케줄러/웹훅/수동 API 중 하나 필요)
-> 스케줄링으로 하는 방식이 좋아보임

- trackingNumber 정합성 문제

현재 포맷 검증/중복 검증이 약하면 오입력 가능
택배사 코드 + 운송장 형식 검증, 재등록 정책(수정 허용 여부) 정의 필요