### PR TITLE
fix: 결제 완료 후 재고 수량 미차감 버그 수정

### DIFF
--- a/src/main/java/org/son/sonstudy/common/api/code/ErrorCode.java
+++ b/src/main/java/org/son/sonstudy/common/api/code/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
     INVALID_STOCK("DC400_303", HttpStatus.BAD_REQUEST, "재고량은 음수가 될 수 없습니다."),
     INVALID_IMAGE_SIZE("DC400_304", HttpStatus.BAD_REQUEST, "상품 이미지는 1-10장 사이여야 합니다."),
     INVALID_PRODUCT_STATE("DC400_305", HttpStatus.BAD_REQUEST , "상품 판매 상태가 정의되지 않았습니다." ),
+    OUT_OF_STOCK("DC400_306", HttpStatus.BAD_REQUEST, "재고가 부족합니다."),
 
     // DELIVERY
     INVALID_DELIVERY_STATUS("DC400_501", HttpStatus.BAD_REQUEST, "현재 배송 상태에서는 해당 작업을 수행할 수 없습니다."),;

--- a/src/main/java/org/son/sonstudy/domain/order/business/OrderService.java
+++ b/src/main/java/org/son/sonstudy/domain/order/business/OrderService.java
@@ -99,6 +99,7 @@ public class OrderService {
 
         payment.attachOrder(order);
         payment.markPaid(gatewayResult.pgTransactionId());
+        productOption.decreaseStock(1);
         paymentRepository.save(payment);
 
         return toResponse(payment);

--- a/src/main/java/org/son/sonstudy/domain/product/model/ProductOption.java
+++ b/src/main/java/org/son/sonstudy/domain/product/model/ProductOption.java
@@ -32,6 +32,9 @@ public class ProductOption {
     @Column(nullable = false)
     private Long totalSales;
 
+    @Version
+    private Long version;
+
     @Enumerated(EnumType.STRING)
     private ProductStatus status;
 
@@ -47,6 +50,16 @@ public class ProductOption {
         this.stock = stock;
         this.totalSales = 0L;
         this.status = status;
+    }
+
+    public void decreaseStock(int quantity) {
+        if (this.stock - quantity < 0) {
+            throw new CustomException(ErrorCode.OUT_OF_STOCK);
+        }
+        this.stock -= quantity;
+        if (this.stock == 0) {
+            this.status = ProductStatus.SOLD_OUT;
+        }
     }
 
     private void validateSize(int size) {


### PR DESCRIPTION
## 📌 Issue
<!-- 관련 이슈 번호 -->
- closed #51 

## ✍️ Summary
<!-- 이슈에 대한 설명 -->
구매 확정 후 재고 차감 안하는 문제 수정

### 변경사항
1. `ProductOption.java` - `decreaseStock` 메소드:
       * 음수 재고를 방지하고 (stock - quantity < 0일 경우 ErrorCode.OUT_OF_STOCK 발생), 재고를 정확히 줄이며, 재고가 0이 되면 ProductStatus.SOLD_OUT으로 상태를 업데이트


2. `ProductOption.java` - `@Version` 필드:
       * @Version 필드는 낙관적 락을 활성화하여 동시성 문제를 해결하는 핵심 메커니즘. 여러 트랜잭션이 동시에 동일한 엔티티를 수정하려 할 때, 버전 불일치가 발생하면 OptimisticLockException이 발생하여 데이터 무결성을 보장

   
3. `OrderService.java` - `checkout` 메소드:
       * decreaseStock(1) 메소드는 @Transactional로 설정된 checkout 메소드 내에서 결제 성공 후 호출됩니다. JPA는 이 트랜잭션 커밋 시 ProductOption 엔티티 업데이트를 시도하며, 이때 @Version 필드를 통해 낙관적 락이 작동
       * 이는 여러 사용자가 동시에 주문을 시도하여 재고를 변경할 때, 단 하나의 트랜잭션만 성공하고 나머지 트랜잭션은 OptimisticLockException을 발생시켜 과다 판매를 방지하는 구조


## 📢 Notify
<!-- 리뷰어 참고 사항-->
