### PR TITLE
fix: 상품 옵션 등록 시 status 누락으로 인한 INVALID_PRODUCT_STATE 예외 수정

### DIFF
--- a/src/main/java/org/son/sonstudy/domain/product/application/request/ProductRegistrationRequest.java
+++ b/src/main/java/org/son/sonstudy/domain/product/application/request/ProductRegistrationRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import org.son.sonstudy.domain.product.model.ProductCategory;
+import org.son.sonstudy.domain.product.model.ProductStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -49,6 +50,9 @@ public record ProductRegistrationRequest(
                 int cost,
 
                 @Min(value = 0, message = "재고에 음수를 입력할 수 없습니다.")
-                int stock
+                int stock,
+
+                @NotNull(message = "옵션 상태는 필수입니다.")
+                ProductStatus status
         ) {}
 }

--- a/src/main/java/org/son/sonstudy/domain/product/business/ProductServiceImpl.java
+++ b/src/main/java/org/son/sonstudy/domain/product/business/ProductServiceImpl.java
@@ -78,6 +78,7 @@ public class ProductServiceImpl implements ProductService {
                     .size(optionDto.size())
                     .cost(optionDto.cost())
                     .stock(optionDto.stock())
+                    .status(optionDto.status())
                     .build();
 
             option.setProduct(product);


### PR DESCRIPTION
## 📌 Issue
<!-- 관련 이슈 번호 -->
- closed #54 

## ✍️ Summary
<!-- 이슈에 대한 설명 -->
-`ProductRegistrationRequest.OptionRequest`에 `status` 필드 추가
- `ProductServiceImpl`에서 `ProductOption` 빌더에 `.status(optionDto.status())` 전달
- `size`, `cost`, `stock`과 동일하게 클라이언트가 `status`를 직접 전달하도록 수정했습니다.

## 📢 Notify
<!-- 리뷰어 참고 사항-->
[P0] 상품 등록 api 500에러 발생 → 원인: productRegistration에 brand 필드가 없어 매핑 안됨 
-> 이 문제는 현재 발견되지 않는 것으로 확인됩니다. 추후 이런 내용의 버그 발생 시 재확인 해보면 될 것 같습니다.
- 추가 논의 사항
  현재 `Product.createProduct()`에서 상품 상태가 `SCHEDULED`로 하드코딩되어 있습니다.
  
    ```java
    // Product.java
    .status(ProductStatus.SCHEDULED) // 항상 고정
  
    ProductOption의 status는 이번 PR에서 클라이언트가 직접 지정하도록 수정했으나,
    Product 자체의 상태 전환 로직(SCHEDULED → ON_SALE → SOLD_OUT → END)은
    현재 코드 어디에도 존재하지 않습니다.
  
    - 스케줄러 기반으로 releasedAt 시각에 자동 전환할 것인지
    - 별도 API로 수동 전환할 것인지
  
    추후 이슈로 분리해서 논의가 필요할 것 같습니다.

