### PR TITLE
fix: FAILED 결제 건에 대한 재시도 불가 및 취소된 주문에도 배송 등록 가능 수정

### DIFF
--- a/src/main/java/org/son/sonstudy/common/api/code/ErrorCode.java
+++ b/src/main/java/org/son/sonstudy/common/api/code/ErrorCode.java
@@ -40,6 +40,9 @@ public enum ErrorCode {
     INVALID_IMAGE_SIZE("DC400_304", HttpStatus.BAD_REQUEST, "상품 이미지는 1-10장 사이여야 합니다."),
     INVALID_PRODUCT_STATE("DC400_305", HttpStatus.BAD_REQUEST , "상품 판매 상태가 정의되지 않았습니다." ),
 
+    // ORDER
+    INVALID_ORDER_STATUS("DC400_401", HttpStatus.BAD_REQUEST, "현재 주문 상태에서는 해당 작업을 수행할 수 없습니다."),
+
     // DELIVERY
     INVALID_DELIVERY_STATUS("DC400_501", HttpStatus.BAD_REQUEST, "현재 배송 상태에서는 해당 작업을 수행할 수 없습니다."),;
 

--- a/src/main/java/org/son/sonstudy/domain/delivery/business/DeliveryService.java
+++ b/src/main/java/org/son/sonstudy/domain/delivery/business/DeliveryService.java
@@ -10,6 +10,7 @@ import org.son.sonstudy.domain.delivery.business.tracker.DeliveryTrackingResult;
 import org.son.sonstudy.domain.delivery.model.Delivery;
 import org.son.sonstudy.domain.delivery.model.DeliveryStatus;
 import org.son.sonstudy.domain.order.model.Order;
+import org.son.sonstudy.domain.order.model.OrderStatus;
 import org.son.sonstudy.domain.order.repository.OrderRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +26,10 @@ public class DeliveryService {
     public DeliveryShipmentResponse registerShipment(String orderId, DeliveryShipmentRequest request) {
         Order order = orderRepository.findWithDeliveryById(orderId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+
+        if (order.getStatus() != OrderStatus.PURCHASED) {
+            throw new CustomException(ErrorCode.INVALID_ORDER_STATUS);
+        }
 
         Delivery delivery = order.getDelivery();
         delivery.registerShipment(request.courierCompany(), request.trackingNumber());

--- a/src/main/java/org/son/sonstudy/domain/order/business/OrderService.java
+++ b/src/main/java/org/son/sonstudy/domain/order/business/OrderService.java
@@ -15,6 +15,7 @@ import org.son.sonstudy.domain.payment.business.pg.PaymentApproveCommand;
 import org.son.sonstudy.domain.payment.business.pg.PaymentGateway;
 import org.son.sonstudy.domain.payment.business.pg.PaymentGatewayResult;
 import org.son.sonstudy.domain.payment.model.Payment;
+import org.son.sonstudy.domain.payment.model.PaymentStatus;
 import org.son.sonstudy.domain.payment.repository.PaymentRepository;
 import org.son.sonstudy.domain.product.model.ProductOption;
 import org.son.sonstudy.domain.product.model.ProductStatus;
@@ -65,7 +66,7 @@ public class OrderService {
     @Loggable(category = LogCategory.ORDER)
     public CheckoutResponse checkout(String userId, CheckoutRequest request) {
         Payment existingPayment = paymentRepository.findByMerchantUid(request.idempotencyKey()).orElse(null);
-        if (existingPayment != null) {
+        if (existingPayment != null && existingPayment.getStatus() != PaymentStatus.FAILED) {
             return toResponse(existingPayment);
         }
 
@@ -76,11 +77,17 @@ public class OrderService {
 
         validateCheckoutRequest(userId, request, productOption);
 
-        Payment payment = Payment.createRequested(
-                request.idempotencyKey(),
-                request.paymentMethod(),
-                request.amount()
-        );
+        Payment payment;
+        if (existingPayment != null) {
+            payment = existingPayment;
+            payment.recreateRequested(request.paymentMethod(), request.amount());
+        } else {
+            payment = Payment.createRequested(
+                    request.idempotencyKey(),
+                    request.paymentMethod(),
+                    request.amount()
+            );
+        }
         paymentRepository.save(payment);
 
         PaymentGatewayResult gatewayResult = paymentGateway.approve(new PaymentApproveCommand(

--- a/src/main/java/org/son/sonstudy/domain/payment/model/Payment.java
+++ b/src/main/java/org/son/sonstudy/domain/payment/model/Payment.java
@@ -100,4 +100,17 @@ public class Payment {
         this.failureMessage = failureMessage;
         this.approvedAt = null;
     }
+
+    public void recreateRequested(PaymentMethod method, Long amount) {
+        this.status = PaymentStatus.REQUESTED;
+        this.method = method;
+        this.amount = amount;
+        this.requestedAt = LocalDateTime.now();
+        this.approvedAt = null;
+        this.failedAt = null;
+        this.failureCode = null;
+        this.failureMessage = null;
+        this.pgTransactionId = null;
+        this.order = null;
+    }
 }

--- a/src/test/java/org/son/sonstudy/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/org/son/sonstudy/domain/order/service/OrderServiceTest.java
@@ -276,6 +276,44 @@ public class OrderServiceTest {
                 assertThat(savedPayment.getFailureCode()).isEqualTo("FAKE_PG_DECLINED");
             }
         }
+
+        @Nested
+        class 실패한_결제를_재시도하면 {
+
+            @Test
+            void 기존_실패_레코드를_재활용하여_결제승인을_재시도하고_성공하면_주문이_생성된다() {
+                // given
+                String idempotencyKey = "checkout-retry-success";
+
+                Payment failedPayment = Payment.createRequested(
+                        idempotencyKey,
+                        PaymentMethod.CARD,
+                        (long) defaultProductOption.getCost()
+                );
+                failedPayment.markFailed("TEMP_ERR", "임시 결제 실패");
+                paymentRepository.save(failedPayment);
+
+                CheckoutRequest request = createCheckoutRequest(idempotencyKey);
+
+                // when
+                CheckoutResponse response = orderService.checkout(defaultUser.getId(), request);
+
+                // then
+                assertThat(response.orderId()).isNotNull();
+                assertThat(response.orderStatus()).isEqualTo(OrderStatus.PURCHASED);
+                assertThat(response.paymentId()).isEqualTo(failedPayment.getId());
+                assertThat(response.paymentStatus()).isEqualTo(PaymentStatus.PAID);
+                assertThat(response.failureCode()).isNull();
+                assertThat(response.failureMessage()).isNull();
+
+                assertThat(paymentRepository.count()).isEqualTo(1);
+
+                Payment savedPayment = paymentRepository.findByMerchantUid(idempotencyKey).orElseThrow();
+                assertThat(savedPayment.getStatus()).isEqualTo(PaymentStatus.PAID);
+                assertThat(savedPayment.getOrder()).isNotNull();
+                assertThat(savedPayment.getOrder().getId()).isEqualTo(response.orderId());
+            }
+        }
     }
 
     @Nested


### PR DESCRIPTION
## 📌 Issue
<!-- 관련 이슈 번호 -->
- closed #53

## ✍️ Summary
<!-- 이슈에 대한 설명 -->
#### 결제 FAILED 상태건에 관하여 같은 idempotency key로 재시도 불가 이슈
변경 로직:
1. idempotencyKey로 조회된 기존 결제(existingPayment)가 존재할 때, 상태가 FAILED가 아닌 경우(성공 PAID 또는 진행 중 REQUESTED)에만 기존 멱등성 규칙대로 즉시 응답을 반환
2. 상태가 FAILED인 경우에는, 기존 실패 레코드를 그대로 재활용하여 결제 수단과 금액을 업데이트하고 상태를 다시 REQUESTED로 설정
3. 재시도 시점 사이에 상품의 재고 소진, 가격 변동, 중복 구매 여부 등이 바뀔 수 있으므로 도메인 검증(validateCheckoutRequest)은 반드시 다시 수행
4. PG 승인 요청을 다시 시도하고 결과에 따라 PAID 또는 FAILED로 해당 레코드를 갱신 (실패 시에는 Order가 생성되지 않고, 최종 성공 시에만 Order가 새롭게 생성되어 결제 레코드와 매핑됨)

#### 취소된 주문에도 배송 등록 가능 이슈
변경 로직:
Order의 status도 검증해서 PURCHASED가 아닌 상태인 주문에 대해서는 배송 등록이 안되도록 수정

## 📢 Notify
<!-- 리뷰어 참고 사항-->
