### PR TITLE
refactor: checkout 메서드 가독성 위해 내부 로직  캡슐화

### DIFF
--- a/src/main/java/org/son/sonstudy/domain/order/business/OrderService.java
+++ b/src/main/java/org/son/sonstudy/domain/order/business/OrderService.java
@@ -66,7 +66,7 @@ public class OrderService {
     @Loggable(category = LogCategory.ORDER)
     public CheckoutResponse checkout(String userId, CheckoutRequest request) {
         Payment existingPayment = paymentRepository.findByMerchantUid(request.idempotencyKey()).orElse(null);
-        if (existingPayment != null && existingPayment.getStatus() != PaymentStatus.FAILED) {
+        if (isAlreadyProcessed(existingPayment)) {
             return toResponse(existingPayment);
         }
 
@@ -77,24 +77,35 @@ public class OrderService {
 
         validateCheckoutRequest(userId, request, productOption);
 
-        Payment payment;
-        if (existingPayment != null) {
-            payment = existingPayment;
-            payment.recreateRequested(request.paymentMethod(), request.amount());
-        } else {
-            payment = Payment.createRequested(
-                    request.idempotencyKey(),
-                    request.paymentMethod(),
-                    request.amount()
-            );
-        }
+        Payment payment = getOrCreatePayment(existingPayment, request);
         paymentRepository.save(payment);
 
+        return processPaymentApproval(user, productOption, payment, request);
+    }
+
+    private boolean isAlreadyProcessed(Payment payment) {
+        return payment != null && payment.getStatus() != PaymentStatus.FAILED;
+    }
+
+    private Payment getOrCreatePayment(Payment existingPayment, CheckoutRequest request) {
+        if (existingPayment != null) {
+            existingPayment.recreateRequested(request.paymentMethod(), request.amount());
+            return existingPayment;
+        }
+        return Payment.createRequested(
+                request.idempotencyKey(),
+                request.paymentMethod(),
+                request.amount()
+        );
+    }
+
+    private CheckoutResponse processPaymentApproval(User user, ProductOption productOption, Payment payment, CheckoutRequest request) {
         PaymentGatewayResult gatewayResult = paymentGateway.approve(new PaymentApproveCommand(
                 request.idempotencyKey(),
                 request.paymentMethod(),
                 request.amount()
         ));
+
         if (!gatewayResult.success()) {
             payment.markFailed(gatewayResult.failureCode(), gatewayResult.failureMessage());
             paymentRepository.save(payment);


### PR DESCRIPTION
## 📌 Issue
<!-- 관련 이슈 번호 -->
- closed #53 

## ✍️ Summary
<!-- 이슈에 대한 설명 -->

 **① 중복 처리 여부 판별 검증 캡슐화 (isAlreadyProcessed)**
   * 이전: existingPayment != null && existingPayment.getStatus() != PaymentStatus.FAILED와 같이 날것의 상태 비교식이 메서드 최상단에 존재하여 비즈니스 의도가 모호했습니다.
   * 이후: isAlreadyProcessed 메서드로 캡슐화하여 "결제가 실패(FAILED) 상태가 아닌 다른 상태로 이미 가공되었는지" 판단하는 역할을 명확히 위임했습니다.

  **② 결제 엔티티 준비 로직 캡슐화 (getOrCreatePayment)**
   * 이전: 동일한 멱등성 키가 존재하느냐 실패했느냐에 따라 분기(if-else)하여 엔티티를 가공하고 재생성하는 로직이 메인 비즈니스 흐름 한가운데 섞여 있었습니다.
   * 이후: getOrCreatePayment 전용 메서드를 작성하여, 기존 실패 건이 있으면 Payment.recreateRequested를 통해 객체 상태를 안전하게 초기화/업데이트하고, 없으면 신규 Payment를 생성하는 엔티티 생성 책임(Factory 역할)을 완전히 격리했습니다.

  **③ PG사 결제 승인 및 주문 연동 로직 캡슐화 (processPaymentApproval)**
   * 이전: PG API 호출, 실패 시 마킹, 성공 시 주문 생성, 주문 엔티티 저장, 결제와 주문 연결, PAID 상태 마킹 등 매우 빽빽하고 흐름이 긴 인프라성 연동 코드가 모두 checkout 안에 있었습니다.
   * 이후: 이 모든 절차를 processPaymentApproval 내부로 분리하여 "PG사의 실제 통신 성공 유무에 따른 보상 또는 후처리 비즈니스"를 격리함으로써 메인 로직의 복잡성을 낮추었습니다.


## 📢 Notify
<!-- 리뷰어 참고 사항-->
기능상 변경은 없습니다.
OrderService의 checkout 메서드 가독성을 위해 내부 로직들을 메서드로 추출했습니다.

금주 회의 불참 이슈로 인해 문제 없다고 판단될 시에 대신 머지 부탁드립니당